### PR TITLE
Use normal surface background in repos-hub

### DIFF
--- a/src/repos-hub/ServiceHub.tsx
+++ b/src/repos-hub/ServiceHub.tsx
@@ -91,7 +91,7 @@ class RepositoryServiceHubContent extends React.Component<{}, IRepositoryService
 
     public render(): JSX.Element {
         return (
-            <Surface background={SurfaceBackground.neutral}>
+            <Surface background={SurfaceBackground.normal}>
                 <Page className="sample-hub flex-grow">
 
                     <Header title={"Git repositories (" + this.state.nbrRepos + ")"}


### PR DESCRIPTION
The Repos section in ADO uses a white background (SurfaceBackground.normal). The neutral grey applied previously matches the collection home context but not the code hub group where the repos-hub lives.