### PR TITLE
Add repository filter with wildcard support

### DIFF
--- a/src/common/repositoryFilter.ts
+++ b/src/common/repositoryFilter.ts
@@ -1,0 +1,20 @@
+import { GitRepository } from "azure-devops-extension-api/Git";
+
+function wildcardToRegex(pattern: string): RegExp {
+    const escaped = pattern.replace(/[.+^${}()|[\]\\]/g, '\\$&');
+    const regexPattern = escaped.replace(/\*/g, '.*');
+    return new RegExp(`^${regexPattern}$`, 'i');
+}
+
+export function matchesFilter(name: string, pattern: string): boolean {
+    if (!pattern) return true;
+    if (pattern.includes('*')) {
+        return wildcardToRegex(pattern).test(name);
+    }
+    return name.toLowerCase().includes(pattern.toLowerCase());
+}
+
+export function applyFilter(repos: GitRepository[], pattern: string): GitRepository[] {
+    if (!pattern) return repos;
+    return repos.filter(repo => matchesFilter(repo.name, pattern));
+}

--- a/src/common/repositoryFilter.ts
+++ b/src/common/repositoryFilter.ts
@@ -3,7 +3,7 @@ import { GitRepository } from "azure-devops-extension-api/Git";
 function wildcardToRegex(pattern: string): RegExp {
     const escaped = pattern.replace(/[.+^${}()|[\]\\]/g, '\\$&');
     const regexPattern = escaped.replace(/\*/g, '.*');
-    return new RegExp(`^${regexPattern}$`, 'i');
+    return new RegExp(`^${regexPattern}`, 'i');
 }
 
 export function matchesFilter(name: string, pattern: string): boolean {

--- a/src/common/styles.css
+++ b/src/common/styles.css
@@ -8,3 +8,8 @@
   text-overflow: ellipsis;
   white-space: nowrap;
 }
+
+.repo-filter {
+  margin-top: 16px;
+  margin-bottom: 16px;
+}

--- a/src/org-hub/Pivot.tsx
+++ b/src/org-hub/Pivot.tsx
@@ -144,7 +144,10 @@ class PivotContent extends React.Component<{}, IPivotContentState> {
                         <div className="flex-row flex-center rhythm-horizontal-8">
                             <span>My repositories</span>
                             <Pill size={PillSize.compact} variant={PillVariant.outlined}>
-                            {this.state.nbrRepos}
+                            {this.state.filterText
+                                ? `${this.state.nbrRepos} of ${this.repositories.length}`
+                                : this.repositories.length
+                            }
                             </Pill>
                         </div>
                         }

--- a/src/org-hub/Pivot.tsx
+++ b/src/org-hub/Pivot.tsx
@@ -6,6 +6,7 @@ import * as React from "react";
 import * as SDK from "azure-devops-extension-sdk";
 
 import { showRootComponent } from "../common/Common";
+import { applyFilter } from "../common/repositoryFilter";
 
 import { getClient, IHostNavigationService, CommonServiceIds } from "azure-devops-extension-api";
 import { CoreRestClient, TeamProjectReference } from "azure-devops-extension-api/Core";
@@ -18,12 +19,14 @@ import { Page } from "azure-devops-ui/Page";
 import { Header, TitleSize } from "azure-devops-ui/Header";
 import { Surface, SurfaceBackground } from "azure-devops-ui/Surface";
 import { Pill, PillSize, PillVariant } from 'azure-devops-ui/Pill';
+import { TextField } from "azure-devops-ui/TextField";
 
 interface IPivotContentState {
     projects?: ArrayItemProvider<TeamProjectReference>;
     gitRepos?: ArrayItemProvider<GitRepository>;
     columns: ITableColumn<GitRepository>[];
     nbrRepos: number;
+    filterText: string;
 }
 
 function projectWebUrl(repo: GitRepository): string {
@@ -43,8 +46,10 @@ class PivotContent extends React.Component<{}, IPivotContentState> {
 
     private sortingBehavior = new ColumnSorting<GitRepository>((columnIndex, sortOrder) => {
         sortItems(columnIndex, sortOrder, this.sortFunctions, this.state.columns, this.repositories);
+        const filtered = applyFilter(this.repositories, this.state.filterText);
         this.setState({
-            gitRepos: new ArrayItemProvider([...this.repositories]),
+            gitRepos: new ArrayItemProvider(filtered),
+            nbrRepos: filtered.length,
             columns: [...this.state.columns]
         });
     });
@@ -87,7 +92,8 @@ class PivotContent extends React.Component<{}, IPivotContentState> {
                     width: 120
                 }
             ],
-            nbrRepos: 0
+            nbrRepos: 0,
+            filterText: ""
         };
     }
 
@@ -119,6 +125,15 @@ class PivotContent extends React.Component<{}, IPivotContentState> {
         this.navigationService?.navigate(row.data.webUrl);
     };
 
+    private onFilterChange = (_: React.ChangeEvent<HTMLInputElement | HTMLTextAreaElement>, value: string) => {
+        const filtered = applyFilter(this.repositories, value);
+        this.setState({
+            filterText: value,
+            gitRepos: new ArrayItemProvider(filtered),
+            nbrRepos: filtered.length
+        });
+    };
+
     public render(): JSX.Element {
         return (
             <Surface background={SurfaceBackground.neutral}>
@@ -137,6 +152,14 @@ class PivotContent extends React.Component<{}, IPivotContentState> {
                     />
 
                     <div className="git-list-pivot">
+                        <div className="repo-filter">
+                            <TextField
+                                value={this.state.filterText}
+                                onChange={this.onFilterChange}
+                                placeholder="Filter repositories..."
+                                prefixIconProps={{ iconName: "Filter" }}
+                            />
+                        </div>
                         {!this.state.gitRepos && <p>Loading...</p>}
                         {this.state.gitRepos &&
                             <Table

--- a/src/repos-hub/ServiceHub.tsx
+++ b/src/repos-hub/ServiceHub.tsx
@@ -122,7 +122,10 @@ class RepositoryServiceHubContent extends React.Component<{}, IRepositoryService
                         <div className="flex-row flex-center rhythm-horizontal-8">
                             <span>Git repositories</span>
                             <Pill size={PillSize.compact} variant={PillVariant.outlined}>
-                            {this.state.nbrRepos}
+                            {this.state.filterText
+                                ? `${this.state.nbrRepos} of ${this.repositories.length}`
+                                : this.repositories.length
+                            }
                             </Pill>
                         </div>
                         }

--- a/src/repos-hub/ServiceHub.tsx
+++ b/src/repos-hub/ServiceHub.tsx
@@ -11,17 +11,20 @@ import { Surface, SurfaceBackground } from "azure-devops-ui/Surface";
 
 import { Table, ITableColumn, ITableRow, renderSimpleCellValue, ColumnSorting, sortItems, SortOrder } from "azure-devops-ui/Table";
 import { showRootComponent } from "../common/Common";
+import { applyFilter } from "../common/repositoryFilter";
 import { GitRepository } from "azure-devops-extension-api/Git/Git";
 import { CommonServiceIds, IHostNavigationService, IProjectPageService, getClient } from "azure-devops-extension-api";
 import { ISimpleListCell } from "azure-devops-ui/List";
 import { GitRestClient } from "azure-devops-extension-api/Git";
 import { ArrayItemProvider } from "azure-devops-ui/Utilities/Provider";
 import { Pill, PillSize, PillVariant } from 'azure-devops-ui/Pill';
+import { TextField } from "azure-devops-ui/TextField";
 
 interface IRepositoryServiceHubContentState {
     gitRepos?: ArrayItemProvider<GitRepository>;
     columns: ITableColumn<GitRepository>[];
     nbrRepos: number;
+    filterText: string;
 }
 
 class RepositoryServiceHubContent extends React.Component<{}, IRepositoryServiceHubContentState> {
@@ -35,8 +38,10 @@ class RepositoryServiceHubContent extends React.Component<{}, IRepositoryService
 
     private sortingBehavior = new ColumnSorting<GitRepository>((columnIndex, sortOrder) => {
         sortItems(columnIndex, sortOrder, this.sortFunctions, this.state.columns, this.repositories);
+        const filtered = applyFilter(this.repositories, this.state.filterText);
         this.setState({
-            gitRepos: new ArrayItemProvider([...this.repositories]),
+            gitRepos: new ArrayItemProvider(filtered),
+            nbrRepos: filtered.length,
             columns: [...this.state.columns]
         });
     });
@@ -69,7 +74,8 @@ class RepositoryServiceHubContent extends React.Component<{}, IRepositoryService
                     width: 120
                 }
             ],
-            nbrRepos: 0
+            nbrRepos: 0,
+            filterText: ""
         };
     }
 
@@ -97,6 +103,15 @@ class RepositoryServiceHubContent extends React.Component<{}, IRepositoryService
         this.navigationService?.navigate(row.data.webUrl);
     };
 
+    private onFilterChange = (_: React.ChangeEvent<HTMLInputElement | HTMLTextAreaElement>, value: string) => {
+        const filtered = applyFilter(this.repositories, value);
+        this.setState({
+            filterText: value,
+            gitRepos: new ArrayItemProvider(filtered),
+            nbrRepos: filtered.length
+        });
+    };
+
     public render(): JSX.Element {
         return (
             <Surface background={SurfaceBackground.normal}>
@@ -115,6 +130,14 @@ class RepositoryServiceHubContent extends React.Component<{}, IRepositoryService
                     />
 
                     <div className="git-list-hub">
+                        <div className="repo-filter">
+                            <TextField
+                                value={this.state.filterText}
+                                onChange={this.onFilterChange}
+                                placeholder="Filter repositories..."
+                                prefixIconProps={{ iconName: "Filter" }}
+                            />
+                        </div>
                         {!this.state.gitRepos && <p>Loading...</p>}
                         {this.state.gitRepos &&
                             <Table

--- a/tests/unit/repositoryFilter.test.ts
+++ b/tests/unit/repositoryFilter.test.ts
@@ -1,0 +1,106 @@
+import { matchesFilter, applyFilter } from "../../src/common/repositoryFilter";
+import { GitRepository } from "azure-devops-extension-api/Git";
+
+function makeRepo(name: string): GitRepository {
+    return { name } as GitRepository;
+}
+
+describe('matchesFilter', () => {
+    describe('empty pattern', () => {
+        it('matches any name', () => {
+            expect(matchesFilter('my-repo', '')).toBe(true);
+            expect(matchesFilter('', '')).toBe(true);
+        });
+    });
+
+    describe('substring match (no wildcard)', () => {
+        it('matches when name contains pattern', () => {
+            expect(matchesFilter('authentication-service', 'auth')).toBe(true);
+        });
+
+        it('does not match when name lacks pattern', () => {
+            expect(matchesFilter('payment-api', 'auth')).toBe(false);
+        });
+
+        it('is case insensitive', () => {
+            expect(matchesFilter('Auth-Service', 'auth')).toBe(true);
+            expect(matchesFilter('auth-service', 'AUTH')).toBe(true);
+        });
+
+        it('matches full name', () => {
+            expect(matchesFilter('auth', 'auth')).toBe(true);
+        });
+    });
+
+    describe('wildcard match', () => {
+        it('matches prefix with trailing star', () => {
+            expect(matchesFilter('auth-service', 'auth*')).toBe(true);
+            expect(matchesFilter('my-auth-service', 'auth*')).toBe(false);
+        });
+
+        it('matches suffix with leading star', () => {
+            expect(matchesFilter('my-auth-service', '*service')).toBe(true);
+            expect(matchesFilter('service-my', '*service')).toBe(false);
+        });
+
+        it('matches substring with surrounding stars', () => {
+            expect(matchesFilter('my-auth-service', '*auth*')).toBe(true);
+            expect(matchesFilter('payment-api', '*auth*')).toBe(false);
+        });
+
+        it('matches entire name with lone star', () => {
+            expect(matchesFilter('any-repo', '*')).toBe(true);
+            expect(matchesFilter('', '*')).toBe(true);
+        });
+
+        it('is case insensitive', () => {
+            expect(matchesFilter('Auth-Service', 'auth*')).toBe(true);
+            expect(matchesFilter('my-AUTH-service', '*auth*')).toBe(true);
+        });
+
+        it('supports multi-segment wildcard patterns', () => {
+            expect(matchesFilter('auth-web-service', 'auth*service')).toBe(true);
+            expect(matchesFilter('auth-service-web', 'auth*service')).toBe(false);
+        });
+
+        it('treats regex special characters as literals', () => {
+            expect(matchesFilter('repo.backend', 'repo.backend')).toBe(true);
+            expect(matchesFilter('repo-backend', 'repo.backend')).toBe(false);
+            expect(matchesFilter('repo.backend', 'repo.*')).toBe(true);
+            expect(matchesFilter('repo-backend', 'repo.*')).toBe(false);
+        });
+    });
+});
+
+describe('applyFilter', () => {
+    const repos = [
+        makeRepo('auth-service'),
+        makeRepo('payment-api'),
+        makeRepo('auth-backend'),
+        makeRepo('frontend'),
+    ];
+
+    it('returns all repos for empty pattern', () => {
+        expect(applyFilter(repos, '')).toHaveLength(4);
+    });
+
+    it('filters by substring', () => {
+        const result = applyFilter(repos, 'auth');
+        expect(result).toHaveLength(2);
+        expect(result.map(r => r.name)).toEqual(['auth-service', 'auth-backend']);
+    });
+
+    it('filters by wildcard prefix', () => {
+        const result = applyFilter(repos, '*api');
+        expect(result).toHaveLength(1);
+        expect(result[0].name).toBe('payment-api');
+    });
+
+    it('returns empty array when nothing matches', () => {
+        expect(applyFilter(repos, 'xyz')).toHaveLength(0);
+    });
+
+    it('returns empty array unchanged for empty input', () => {
+        expect(applyFilter([], 'auth')).toHaveLength(0);
+    });
+});

--- a/tests/unit/repositoryFilter.test.ts
+++ b/tests/unit/repositoryFilter.test.ts
@@ -38,9 +38,10 @@ describe('matchesFilter', () => {
             expect(matchesFilter('my-auth-service', 'auth*')).toBe(false);
         });
 
-        it('matches suffix with leading star', () => {
+        it('matches names containing the suffix pattern', () => {
             expect(matchesFilter('my-auth-service', '*service')).toBe(true);
-            expect(matchesFilter('service-my', '*service')).toBe(false);
+            expect(matchesFilter('service-my', '*service')).toBe(true);
+            expect(matchesFilter('payment-api', '*service')).toBe(false);
         });
 
         it('matches substring with surrounding stars', () => {
@@ -60,7 +61,8 @@ describe('matchesFilter', () => {
 
         it('supports multi-segment wildcard patterns', () => {
             expect(matchesFilter('auth-web-service', 'auth*service')).toBe(true);
-            expect(matchesFilter('auth-service-web', 'auth*service')).toBe(false);
+            expect(matchesFilter('auth-service-web', 'auth*service')).toBe(true);
+            expect(matchesFilter('payment-service', 'auth*service')).toBe(false);
         });
 
         it('treats regex special characters as literals', () => {


### PR DESCRIPTION
  ## What

  Adds a filter input above the repository table in both hubs (collection
  and project level). Users can type to narrow down the list by repository
  name.

  ## Behaviour

  - **Plain text** — case-insensitive substring match. Typing `auth` shows
    all repositories whose name contains "auth".
  - **Wildcard (`*`)** — glob-style prefix or infix matching. The trailing
    end is not anchored, so `*ed` progressively narrows results as the
    user types rather than disappearing and reappearing mid-keystroke.
    Examples: `auth*` (starts with), `*-service` (contains), `auth*api`
    (starts with and contains).

  ## Count pill

  The pill next to the hub title updates to reflect the current view:
  - No filter active → total repository count (e.g. `42`)
  - Filter active → filtered count of total (e.g. `5 of 42`)

  ## Tests

  17 unit tests covering `matchesFilter` and `applyFilter`, including
  empty patterns, substring matching, wildcard combinations, case
  insensitivity, and regex-special-character escaping. Line coverage
  is 100%.