### PR TITLE
Add tree view to org-hub with ADO-native styling

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -8,6 +8,8 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 
 **Documentation is part of every change.** Whenever a feature is implemented or modified, `README.md`, `overview.md`, and `CLAUDE.md` must all be updated in the same branch before the PR is raised. This is not optional and not a follow-up task — it is part of the definition of done for every change.
 
+**All UI must feel like a natural part of Azure DevOps.** Every design decision — spacing, typography, colour, row height, hover states, dividers, icons — must follow the ADO design language. Use ADO design tokens (`--palette-*`, `--color-*`) rather than hard-coded values. Reach for `azure-devops-ui` components before writing custom HTML. When in doubt, look at how ADO itself renders a similar pattern (branches list, work item list, table) and match it. Never introduce visual styles that feel foreign to the ADO shell.
+
 ## Project Overview
 
 This is an Azure DevOps (ADO) extension named **Git repository list** (id: `git-repository-list`, publisher: `CrazySolutions`). It displays git repositories in a more convenient way and targets Azure DevOps Services and Server via `Microsoft.VisualStudio.Services` in `azure-devops-extension.json`.
@@ -164,9 +166,11 @@ src/
   common/
     Common.tsx            # Shared showRootComponent helper
     repositoryFilter.ts   # Wildcard/substring filter logic for repo name filtering
+    treeUtils.ts          # ProjectNode type, buildProjectNodes, applyFilterToTree
     styles.css            # Shared styles
   org-hub/
     Pivot.tsx             # Entry point for the suite-home tab (collection page)
+    RepoTreeView.tsx      # Tree view component — repos grouped by project
     index.html
     Pivot.css
     Pivot.json            # Contribution manifest fragment
@@ -190,3 +194,13 @@ tests/
 - CSS files are processed by style-loader and css-loader in webpack.
 - Tests use `tsconfig.jest.json` (which sets `module: commonjs`) rather than `tsconfig.json` (which targets ES2020 modules for the browser). Do not change `tsconfig.json` module settings for test compatibility — override in `tsconfig.jest.json` instead.
 - Tests enforce a minimum **80% line coverage** threshold (`npm run test:coverage`).
+
+### Tree view architecture
+
+The organisation-level hub (`Pivot.tsx`) supports two view modes toggled by the user: `"list"` (default, native ADO `Table` component) and `"tree"` (`RepoTreeView` component).
+
+- `treeUtils.ts` owns the `ProjectNode` shape and two pure functions: `buildProjectNodes` (groups repos by `project.id`, sorts alphabetically) and `applyFilterToTree` (runs the repository filter per project, drops empty nodes).
+- `RepoTreeView.tsx` is a stateless functional component that receives pre-computed `nodes`, `expandedProjects` (a `Set<string>`), and callbacks. It renders a header row and one project node per entry.
+- Expand state is split across two `Set<string>` instances in `Pivot` state: `expandedProjects` (user's manual choices, all projects seeded on load) and `filterExpandedProjects` (auto-computed when filter is active). `activeExpandedProjects()` returns whichever is current.
+- The `azure-devops-ui` package does **not** include a Tree component. The visual treatment (folder background `--palette-neutral-4`, 36px row height, border separators, inset chevrons) is implemented in plain CSS to match the ADO branches list.
+- View toggle buttons are always `subtle={true}`; the active state is indicated with `box-shadow: inset 0 0 0 2px` to avoid layout shift from border/padding changes.

--- a/README.md
+++ b/README.md
@@ -46,7 +46,12 @@ To generate a coverage report (minimum 80% line coverage is enforced):
 
 ## My repositories (organisation level)
 
-Available from the collection/organisation start page, this hub lists every git repository across all projects the current user has access to. Columns show the repository name, the project it belongs to, and its size. All columns are sortable.
+Available from the collection/organisation start page, this hub lists every git repository across all projects the current user has access to.
+
+Two view modes are available via the toggle buttons at the top right of the filter bar:
+
+- **List view** (default) — a flat table with sortable columns: repository name, project, and size.
+- **Tree view** — repositories grouped by project, with collapsible project nodes. Each project header shows a count pill (or `3 of 10` when filtering). Styled to match the ADO branches list.
 
 ## Repository list (project level)
 
@@ -59,7 +64,7 @@ Both hubs provide a filter input at the top of the page to narrow the repository
 - **Plain text** — case-insensitive substring match. Typing `auth` shows all repositories whose name contains "auth".
 - **Wildcard (`*`)** — glob-style matching. `auth*` matches names starting with "auth"; `*-service` matches names that contain "-service".
 
-The count pill next to the hub title reflects the current view — `42` when unfiltered, `5 of 42` when a filter is active.
+The count pill next to the hub title reflects the current view — `42` when unfiltered, `5 of 42` when a filter is active. In tree view, filtering automatically expands projects that contain matching repositories.
 
 # References
 

--- a/overview.md
+++ b/overview.md
@@ -16,6 +16,10 @@ This extension adds two new ways to view all the git repositories in your collec
 
 Both views include a filter input at the top of the page. Type any part of a repository name to narrow the list instantly. Wildcard patterns using `*` are also supported — for example `auth*` to match names starting with "auth", or `*-service` to match names containing "-service". The counter next to the page title updates to show how many repositories are currently visible out of the total (e.g. `5 of 42`).
 
+## Tree view (organisation level)
+
+The organisation-level hub offers a toggle between the default flat list and a tree view that groups repositories by project. Each project node can be expanded or collapsed individually. When a filter is active, only projects containing matching repositories are shown, and they expand automatically. The tree view is styled to match the Azure DevOps branches list.
+
 ## Privacy notice
 
 No data is collected from this extension. Your data is your own. For further details see our [privacy policy](https://github.com/CrazySolutions/AzDoExtensionGitList/blob/master/PRIVACY.md).
@@ -24,6 +28,7 @@ No data is collected from this extension. Your data is your own. For further det
 
 ### 1.1.0
 
+- Feature: Tree view added to the organisation-level hub. Toggle between the existing flat list and a new grouped view that organises repositories by project. Each project node is collapsible, shows a repository count pill, and auto-expands when a filter is active.
 - Feature: Filter input added to both hubs. Plain-text typing does a case-insensitive substring match; patterns with `*` use glob-style matching. The count pill next to the title shows `5 of 42` while a filter is active.
 - Feature: Sortable columns — click any column header to toggle between ascending and descending order.
 - Dependency updates and major refactor of the source code

--- a/src/common/treeUtils.ts
+++ b/src/common/treeUtils.ts
@@ -1,0 +1,52 @@
+import { GitRepository } from "azure-devops-extension-api/Git";
+import { applyFilter } from "./repositoryFilter";
+
+export interface ProjectNode {
+    projectId: string;
+    projectName: string;
+    projectUrl: string;
+    repos: GitRepository[];
+    filteredRepos: GitRepository[];
+}
+
+export function projectWebUrl(repo: GitRepository): string {
+    const gitIndex = repo.webUrl.indexOf("/_git/");
+    return gitIndex !== -1 ? repo.webUrl.substring(0, gitIndex) : repo.webUrl;
+}
+
+export function buildProjectNodes(repos: GitRepository[]): ProjectNode[] {
+    const map = new Map<string, ProjectNode>();
+
+    for (const repo of repos) {
+        const id = repo.project.id;
+        if (!map.has(id)) {
+            map.set(id, {
+                projectId: id,
+                projectName: repo.project.name,
+                projectUrl: projectWebUrl(repo),
+                repos: [],
+                filteredRepos: []
+            });
+        }
+        map.get(id)!.repos.push(repo);
+    }
+
+    const nodes = Array.from(map.values());
+    for (const node of nodes) {
+        node.repos.sort((a, b) => a.name.localeCompare(b.name));
+        node.filteredRepos = [...node.repos];
+    }
+    nodes.sort((a, b) => a.projectName.localeCompare(b.projectName));
+
+    return nodes;
+}
+
+export function applyFilterToTree(nodes: ProjectNode[], pattern: string): ProjectNode[] {
+    if (!pattern) {
+        return nodes.map(node => ({ ...node, filteredRepos: node.repos }));
+    }
+
+    return nodes
+        .map(node => ({ ...node, filteredRepos: applyFilter(node.repos, pattern) }))
+        .filter(node => node.filteredRepos.length > 0);
+}

--- a/src/org-hub/Pivot.css
+++ b/src/org-hub/Pivot.css
@@ -1,4 +1,47 @@
 .git-list-pivot {
     font-size: 0.875rem;
     margin: 0 25px;
+    padding-bottom: 16px;
+}
+
+/* Filter row with view toggle buttons */
+.repo-filter--with-toggle {
+    display: flex;
+    align-items: center;
+}
+
+.view-toggle-buttons {
+    display: flex;
+    flex-direction: row;
+    gap: 4px;
+    margin-left: 8px;
+    flex-shrink: 0;
+}
+
+.view-toggle-wrapper {
+    display: flex;
+    border-radius: 2px;
+}
+
+.view-toggle-wrapper--active {
+    box-shadow: 0 0 0 2px currentColor;
+    border-radius: 2px;
+}
+
+
+/* Tree view */
+.tree-project-cell {
+    display: flex;
+    align-items: center;
+    gap: 6px;
+    width: 100%;
+    cursor: pointer;
+}
+
+.tree-project-name {
+    font-weight: 600;
+    flex: 1;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
 }

--- a/src/org-hub/Pivot.tsx
+++ b/src/org-hub/Pivot.tsx
@@ -7,6 +7,8 @@ import * as SDK from "azure-devops-extension-sdk";
 
 import { showRootComponent } from "../common/Common";
 import { applyFilter } from "../common/repositoryFilter";
+import { buildProjectNodes, applyFilterToTree, projectWebUrl, ProjectNode } from "../common/treeUtils";
+import { RepoTreeView } from "./RepoTreeView";
 
 import { getClient, IHostNavigationService, CommonServiceIds } from "azure-devops-extension-api";
 import { CoreRestClient, TeamProjectReference } from "azure-devops-extension-api/Core";
@@ -15,11 +17,15 @@ import { GitRestClient, GitRepository } from "azure-devops-extension-api/Git";
 import { Table, ITableColumn, ITableRow, renderSimpleCellValue, ColumnSorting, sortItems, SortOrder } from "azure-devops-ui/Table";
 import { ArrayItemProvider } from "azure-devops-ui/Utilities/Provider";
 import { ISimpleListCell } from "azure-devops-ui/List";
+import { Card } from "azure-devops-ui/Card";
 import { Page } from "azure-devops-ui/Page";
 import { Header, TitleSize } from "azure-devops-ui/Header";
 import { Surface, SurfaceBackground } from "azure-devops-ui/Surface";
 import { Pill, PillSize, PillVariant } from 'azure-devops-ui/Pill';
 import { TextField } from "azure-devops-ui/TextField";
+import { Button } from "azure-devops-ui/Button";
+
+type ViewMode = "list" | "tree";
 
 interface IPivotContentState {
     projects?: ArrayItemProvider<TeamProjectReference>;
@@ -27,15 +33,14 @@ interface IPivotContentState {
     columns: ITableColumn<GitRepository>[];
     nbrRepos: number;
     filterText: string;
-}
-
-function projectWebUrl(repo: GitRepository): string {
-    const gitIndex = repo.webUrl.indexOf("/_git/");
-    return gitIndex !== -1 ? repo.webUrl.substring(0, gitIndex) : repo.webUrl;
+    viewMode: ViewMode;
+    expandedProjects: Set<string>;
+    filterExpandedProjects: Set<string>;
 }
 
 class PivotContent extends React.Component<{}, IPivotContentState> {
     private repositories: GitRepository[] = [];
+    private allProjectNodes: ProjectNode[] = [];
     private navigationService?: IHostNavigationService;
 
     private sortFunctions: Array<(a: GitRepository, b: GitRepository) => number> = [
@@ -64,10 +69,10 @@ class PivotContent extends React.Component<{}, IPivotContentState> {
                     name: "Repository",
                     sortProps: { sortOrder: SortOrder.ascending },
                     renderCell: (rowIndex, columnIndex, tableColumn, tableItem): JSX.Element => {
-                        const content: ISimpleListCell = { href: tableItem.webUrl, text: tableItem.name };
+                        const content: ISimpleListCell = { text: tableItem.name, iconProps: { iconName: "GitLogo" } };
                         return renderSimpleCellValue<any>(columnIndex, tableColumn, content);
                     },
-                    width: 700
+                    width: -1
                 },
                 {
                     id: "project",
@@ -93,7 +98,10 @@ class PivotContent extends React.Component<{}, IPivotContentState> {
                 }
             ],
             nbrRepos: 0,
-            filterText: ""
+            filterText: "",
+            viewMode: "list",
+            expandedProjects: new Set(),
+            filterExpandedProjects: new Set()
         };
     }
 
@@ -113,11 +121,13 @@ class PivotContent extends React.Component<{}, IPivotContentState> {
         }
 
         this.repositories = sortItems(0, SortOrder.ascending, this.sortFunctions, this.state.columns, repositories);
+        this.allProjectNodes = buildProjectNodes(this.repositories);
 
         this.setState({
             projects: new ArrayItemProvider(projects),
             gitRepos: new ArrayItemProvider([...this.repositories]),
-            nbrRepos: this.repositories.length
+            nbrRepos: this.repositories.length,
+            expandedProjects: new Set(this.allProjectNodes.map(n => n.projectId))
         });
     }
 
@@ -127,14 +137,49 @@ class PivotContent extends React.Component<{}, IPivotContentState> {
 
     private onFilterChange = (_: React.ChangeEvent<HTMLInputElement | HTMLTextAreaElement>, value: string) => {
         const filtered = applyFilter(this.repositories, value);
+
+        const filterExpandedProjects = value
+            ? new Set(applyFilterToTree(this.allProjectNodes, value).map(n => n.projectId))
+            : new Set<string>();
+
         this.setState({
             filterText: value,
             gitRepos: new ArrayItemProvider(filtered),
-            nbrRepos: filtered.length
+            nbrRepos: filtered.length,
+            filterExpandedProjects
         });
     };
 
+    private onToggleViewMode = (mode: ViewMode) => {
+        this.setState({ viewMode: mode });
+    };
+
+    private onToggleProject = (projectId: string) => {
+        this.setState(prevState => {
+            const next = new Set(prevState.expandedProjects);
+            next.has(projectId) ? next.delete(projectId) : next.add(projectId);
+            return { expandedProjects: next };
+        });
+    };
+
+    private pillContent(): string | number {
+        const { filterText, nbrRepos } = this.state;
+        if (filterText) {
+            return `${nbrRepos} of ${this.repositories.length}`;
+        }
+        return this.repositories.length;
+    }
+
+    private activeExpandedProjects(): Set<string> {
+        return this.state.filterText
+            ? this.state.filterExpandedProjects
+            : this.state.expandedProjects;
+    }
+
     public render(): JSX.Element {
+        const { viewMode, filterText, gitRepos } = this.state;
+        const isFiltering = filterText !== "";
+
         return (
             <Surface background={SurfaceBackground.neutral}>
                 <Page className="page-pivot flex-grow">
@@ -144,10 +189,7 @@ class PivotContent extends React.Component<{}, IPivotContentState> {
                         <div className="flex-row flex-center rhythm-horizontal-8">
                             <span>My repositories</span>
                             <Pill size={PillSize.compact} variant={PillVariant.outlined}>
-                            {this.state.filterText
-                                ? `${this.state.nbrRepos} of ${this.repositories.length}`
-                                : this.repositories.length
-                            }
+                                {this.pillContent()}
                             </Pill>
                         </div>
                         }
@@ -155,24 +197,58 @@ class PivotContent extends React.Component<{}, IPivotContentState> {
                     />
 
                     <div className="git-list-pivot">
-                        <div className="repo-filter">
+                        <div className="repo-filter repo-filter--with-toggle">
                             <TextField
-                                value={this.state.filterText}
+                                value={filterText}
                                 onChange={this.onFilterChange}
                                 placeholder="Filter repositories..."
                                 prefixIconProps={{ iconName: "Filter" }}
                             />
+                            <div className="view-toggle-buttons">
+                                <div className={`view-toggle-wrapper${viewMode === "list" ? " view-toggle-wrapper--active" : ""}`}>
+                                    <Button
+                                        subtle={true}
+                                        iconProps={{ iconName: "BulletedList" }}
+                                        ariaLabel="List view"
+                                        ariaPressed={viewMode === "list"}
+                                        onClick={() => this.onToggleViewMode("list")}
+                                    />
+                                </div>
+                                <div className={`view-toggle-wrapper${viewMode === "tree" ? " view-toggle-wrapper--active" : ""}`}>
+                                    <Button
+                                        subtle={true}
+                                        iconProps={{ iconName: "Group" }}
+                                        ariaLabel="Tree view"
+                                        ariaPressed={viewMode === "tree"}
+                                        onClick={() => this.onToggleViewMode("tree")}
+                                    />
+                                </div>
+                            </div>
                         </div>
-                        {!this.state.gitRepos && <p>Loading...</p>}
-                        {this.state.gitRepos &&
-                            <Table
-                                behaviors={[this.sortingBehavior]}
-                                columns={this.state.columns}
-                                itemProvider={this.state.gitRepos}
-                                singleClickActivation={true}
-                                onActivate={this.onRowActivate}
+
+                        {!gitRepos && <p>Loading...</p>}
+
+                        {gitRepos && viewMode === "list" && (
+                            <Card className="flex-column bolt-table-card bolt-card-white" contentProps={{ contentPadding: false }}>
+                                <Table
+                                    behaviors={[this.sortingBehavior]}
+                                    columns={this.state.columns}
+                                    itemProvider={gitRepos}
+                                    singleClickActivation={true}
+                                    onActivate={this.onRowActivate}
+                                />
+                            </Card>
+                        )}
+
+                        {gitRepos && viewMode === "tree" && (
+                            <RepoTreeView
+                                nodes={applyFilterToTree(this.allProjectNodes, filterText)}
+                                expandedProjects={this.activeExpandedProjects()}
+                                onToggleProject={this.onToggleProject}
+                                onNavigateToRepo={(url) => this.navigationService?.navigate(url)}
+                                filterActive={isFiltering}
                             />
-                        }
+                        )}
                     </div>
 
                 </Page>

--- a/src/org-hub/RepoTreeView.tsx
+++ b/src/org-hub/RepoTreeView.tsx
@@ -1,0 +1,119 @@
+import * as React from "react";
+import { GitRepository } from "azure-devops-extension-api/Git";
+import { ProjectNode } from "../common/treeUtils";
+import { Card } from "azure-devops-ui/Card";
+import { Icon } from "azure-devops-ui/Icon";
+import { Pill, PillSize, PillVariant } from "azure-devops-ui/Pill";
+import { Table, ITableColumn, ITableRow, renderSimpleCellValue } from "azure-devops-ui/Table";
+import { ArrayItemProvider } from "azure-devops-ui/Utilities/Provider";
+import { ISimpleListCell } from "azure-devops-ui/List";
+
+type TreeItem =
+    | { kind: "project"; node: ProjectNode; expanded: boolean }
+    | { kind: "repo"; repo: GitRepository };
+
+export interface IRepoTreeViewProps {
+    nodes: ProjectNode[];
+    expandedProjects: Set<string>;
+    onToggleProject: (projectId: string) => void;
+    onNavigateToRepo: (url: string) => void;
+    filterActive: boolean;
+}
+
+function formatSize(bytes: number): string {
+    const raw = Number.isNaN(bytes) ? 0 : bytes;
+    let size = raw / 1000000;
+    if (size > 1000) {
+        return (size / 1000).toFixed(2) + "GB";
+    }
+    return size.toFixed(2) + "MB";
+}
+
+function projectPillContent(node: ProjectNode, filterActive: boolean): string | number {
+    if (filterActive && node.filteredRepos.length !== node.repos.length) {
+        return `${node.filteredRepos.length} of ${node.repos.length}`;
+    }
+    return node.filteredRepos.length;
+}
+
+function buildFlatItems(nodes: ProjectNode[], expandedProjects: Set<string>): TreeItem[] {
+    const items: TreeItem[] = [];
+    for (const node of nodes) {
+        const expanded = expandedProjects.has(node.projectId);
+        items.push({ kind: "project", node, expanded });
+        if (expanded) {
+            for (const repo of node.filteredRepos) {
+                items.push({ kind: "repo", repo });
+            }
+        }
+    }
+    return items;
+}
+
+function buildColumns(filterActive: boolean): ITableColumn<TreeItem>[] {
+    return [
+        {
+            id: "name",
+            name: "Repository",
+            renderCell: (_rowIndex, columnIndex, tableColumn, item) => {
+                if (item.kind === "project") {
+                    const content: ISimpleListCell = {
+                        textNode: (
+                            <div className="tree-project-cell">
+                                <Icon iconName={item.expanded ? "ChevronDown" : "ChevronRight"} className="flex-noshrink" />
+                                <Icon iconName="Folder" className="flex-noshrink" />
+                                <span className="tree-project-name">{item.node.projectName}</span>
+                                <Pill size={PillSize.compact} variant={PillVariant.outlined}>
+                                    {projectPillContent(item.node, filterActive)}
+                                </Pill>
+                            </div>
+                        )
+                    };
+                    return renderSimpleCellValue<any>(columnIndex, tableColumn, content);
+                }
+                const content: ISimpleListCell = {
+                    text: item.repo.name,
+                    iconProps: { iconName: "GitLogo" }
+                };
+                return renderSimpleCellValue<any>(columnIndex, tableColumn, content);
+            },
+            width: -1
+        },
+        {
+            id: "size",
+            name: "Size",
+            renderCell: (_rowIndex, columnIndex, tableColumn, item) => {
+                if (item.kind === "project") {
+                    return renderSimpleCellValue<any>(columnIndex, tableColumn, "");
+                }
+                return renderSimpleCellValue<any>(columnIndex, tableColumn, formatSize(item.repo.size));
+            },
+            width: 80
+        }
+    ];
+}
+
+export function RepoTreeView({ nodes, expandedProjects, onToggleProject, onNavigateToRepo, filterActive }: IRepoTreeViewProps): JSX.Element {
+    const items = buildFlatItems(nodes, expandedProjects);
+    const columns = buildColumns(filterActive);
+
+    const onActivate = (_event: React.SyntheticEvent<HTMLElement>, row: ITableRow<TreeItem>) => {
+        const item = row.data;
+        if (item.kind === "project") {
+            onToggleProject(item.node.projectId);
+        } else {
+            onNavigateToRepo(item.repo.webUrl);
+        }
+    };
+
+    return (
+        <Card className="flex-column bolt-table-card bolt-card-white" contentProps={{ contentPadding: false }}>
+            <Table<TreeItem>
+                columns={columns}
+                itemProvider={new ArrayItemProvider(items)}
+                singleClickActivation={true}
+                onActivate={onActivate}
+            />
+        </Card>
+    );
+}

--- a/src/repos-hub/ServiceHub.tsx
+++ b/src/repos-hub/ServiceHub.tsx
@@ -10,6 +10,7 @@ import { Page } from "azure-devops-ui/Page";
 import { Surface, SurfaceBackground } from "azure-devops-ui/Surface";
 
 import { Table, ITableColumn, ITableRow, renderSimpleCellValue, ColumnSorting, sortItems, SortOrder } from "azure-devops-ui/Table";
+import { Card } from "azure-devops-ui/Card";
 import { showRootComponent } from "../common/Common";
 import { applyFilter } from "../common/repositoryFilter";
 import { GitRepository } from "azure-devops-extension-api/Git/Git";
@@ -56,10 +57,10 @@ class RepositoryServiceHubContent extends React.Component<{}, IRepositoryService
                     name: "Repository",
                     sortProps: { sortOrder: SortOrder.ascending },
                     renderCell: (rowIndex, columnIndex, tableColumn, tableItem): JSX.Element => {
-                        const content: ISimpleListCell = { href: tableItem.webUrl, text: tableItem.name };
+                        const content: ISimpleListCell = { text: tableItem.name, iconProps: { iconName: "GitLogo" } };
                         return renderSimpleCellValue<any>(columnIndex, tableColumn, content);
                     },
-                    width: 900
+                    width: -1
                 },
                 {
                     id: "size",
@@ -142,15 +143,17 @@ class RepositoryServiceHubContent extends React.Component<{}, IRepositoryService
                             />
                         </div>
                         {!this.state.gitRepos && <p>Loading...</p>}
-                        {this.state.gitRepos &&
-                            <Table
-                                behaviors={[this.sortingBehavior]}
-                                columns={this.state.columns}
-                                itemProvider={this.state.gitRepos}
-                                singleClickActivation={true}
-                                onActivate={this.onRowActivate}
-                            />
-                        }
+                        {this.state.gitRepos && (
+                            <Card className="flex-column bolt-table-card bolt-card-white" contentProps={{ contentPadding: false }}>
+                                <Table
+                                    behaviors={[this.sortingBehavior]}
+                                    columns={this.state.columns}
+                                    itemProvider={this.state.gitRepos}
+                                    singleClickActivation={true}
+                                    onActivate={this.onRowActivate}
+                                />
+                            </Card>
+                        )}
                     </div>
                 </Page>
             </Surface>

--- a/tests/unit/RepoTreeView.test.tsx
+++ b/tests/unit/RepoTreeView.test.tsx
@@ -1,0 +1,196 @@
+import * as React from "react";
+import * as ReactDOM from "react-dom";
+import { act } from "react-dom/test-utils";
+import { RepoTreeView } from "../../src/org-hub/RepoTreeView";
+import { ProjectNode } from "../../src/common/treeUtils";
+import { GitRepository } from "azure-devops-extension-api/Git";
+
+jest.mock("azure-devops-ui/Card", () => ({
+    Card: ({ children }: any) => <div data-testid="card">{children}</div>
+}));
+
+jest.mock("azure-devops-ui/Icon", () => ({
+    Icon: ({ iconName, className }: any) => <span data-testid="icon" data-icon={iconName} className={className} />
+}));
+
+jest.mock("azure-devops-ui/Pill", () => ({
+    Pill: ({ children }: any) => <span data-testid="pill">{children}</span>,
+    PillSize: { compact: "compact" },
+    PillVariant: { outlined: "outlined" }
+}));
+
+jest.mock("azure-devops-ui/Table", () => ({
+    Table: ({ itemProvider, onActivate, columns }: any) => {
+        const items: any[] = itemProvider.value;
+        return (
+            <div data-testid="tree-table">
+                {items.map((item: any, i: number) => {
+                    if (item.kind === "project") {
+                        const nameCol = columns?.[0];
+                        const nameCell = nameCol?.renderCell?.(i, 0, nameCol, item);
+                        return (
+                            <div
+                                key={item.node.projectId}
+                                data-testid="project-row"
+                                data-project-id={item.node.projectId}
+                                data-expanded={String(item.expanded)}
+                                onClick={() => onActivate?.({}, { data: item })}
+                            >
+                                {nameCell}
+                            </div>
+                        );
+                    }
+                    return (
+                        <div
+                            key={item.repo.id || i}
+                            data-testid="repo-row"
+                            onClick={() => onActivate?.({}, { data: item })}
+                        >
+                            <a href={item.repo.webUrl} data-testid="repo-link">{item.repo.name}</a>
+                        </div>
+                    );
+                })}
+            </div>
+        );
+    },
+    renderSimpleCellValue: (_colIdx: any, _tableCol: any, content: any) => {
+        if (content?.textNode) {
+            return <td>{content.textNode}</td>;
+        }
+        if (content?.href) {
+            return <td><a href={content.href}>{content.text}</a></td>;
+        }
+        return <td>{typeof content === "string" ? content : null}</td>;
+    }
+}));
+
+jest.mock("azure-devops-ui/Utilities/Provider", () => ({
+    ArrayItemProvider: class {
+        private _items: any[];
+        constructor(items: any[]) { this._items = items; }
+        get value() { return this._items; }
+        get length() { return this._items.length; }
+    }
+}));
+
+function makeRepo(name: string, id: string, webUrl: string = `https://dev.azure.com/org/proj/_git/${name}`): GitRepository {
+    return { id, name, webUrl, size: 1000000 } as unknown as GitRepository;
+}
+
+function makeNode(projectId: string, projectName: string, repoNames: string[]): ProjectNode {
+    const repos = repoNames.map((name, i) => makeRepo(name, `${projectId}-${i}`));
+    return {
+        projectId,
+        projectName,
+        projectUrl: `https://dev.azure.com/org/${projectName}`,
+        repos,
+        filteredRepos: repos
+    };
+}
+
+let container: HTMLDivElement;
+
+beforeEach(() => {
+    container = document.createElement("div");
+    document.body.appendChild(container);
+});
+
+afterEach(() => {
+    ReactDOM.unmountComponentAtNode(container);
+    container.remove();
+});
+
+function render(ui: JSX.Element) {
+    act(() => { ReactDOM.render(ui, container); });
+}
+
+const defaultProps = {
+    expandedProjects: new Set<string>(),
+    onToggleProject: () => {},
+    onNavigateToRepo: () => {},
+    filterActive: false
+};
+
+describe('RepoTreeView', () => {
+    const nodes = [
+        makeNode('p1', 'Alpha', ['auth-service', 'payment-api']),
+        makeNode('p2', 'Beta', ['frontend']),
+    ];
+
+    it('renders inside a Card', () => {
+        render(<RepoTreeView nodes={nodes} {...defaultProps} />);
+        expect(container.querySelector('[data-testid="card"]')).not.toBeNull();
+    });
+
+    it('renders one project row per entry in nodes', () => {
+        render(<RepoTreeView nodes={nodes} {...defaultProps} />);
+        expect(container.querySelectorAll('[data-testid="project-row"]')).toHaveLength(2);
+    });
+
+    it('renders a Folder icon for each project row', () => {
+        render(<RepoTreeView nodes={nodes} {...defaultProps} />);
+        const projectRows = container.querySelectorAll('[data-testid="project-row"]');
+        projectRows.forEach(row => {
+            expect(row.querySelector('[data-testid="icon"][data-icon="Folder"]')).not.toBeNull();
+        });
+    });
+
+    it('renders no repo rows when all projects are collapsed', () => {
+        render(<RepoTreeView nodes={nodes} {...defaultProps} />);
+        expect(container.querySelectorAll('[data-testid="repo-row"]')).toHaveLength(0);
+    });
+
+    it('renders repo rows only for expanded projects', () => {
+        render(<RepoTreeView nodes={nodes} {...defaultProps} expandedProjects={new Set(['p1'])} />);
+        expect(container.querySelectorAll('[data-testid="repo-row"]')).toHaveLength(2);
+    });
+
+    it('calls onToggleProject with the correct projectId when a project row is clicked', () => {
+        const handler = jest.fn();
+        render(<RepoTreeView nodes={nodes} {...defaultProps} onToggleProject={handler} />);
+        act(() => {
+            (container.querySelector('[data-testid="project-row"]') as HTMLElement).click();
+        });
+        expect(handler).toHaveBeenCalledWith('p1');
+    });
+
+    it('calls onNavigateToRepo when a repo row is activated', () => {
+        const handler = jest.fn();
+        render(<RepoTreeView nodes={nodes} {...defaultProps} expandedProjects={new Set(['p1'])} onNavigateToRepo={handler} />);
+        act(() => {
+            (container.querySelector('[data-testid="repo-row"]') as HTMLElement).click();
+        });
+        expect(handler).toHaveBeenCalledWith('https://dev.azure.com/org/proj/_git/auth-service');
+    });
+
+    it('renders ChevronDown icon for expanded projects and ChevronRight for collapsed', () => {
+        render(<RepoTreeView nodes={nodes} {...defaultProps} expandedProjects={new Set(['p1'])} />);
+        const projectRows = container.querySelectorAll('[data-testid="project-row"]');
+        expect(projectRows[0].querySelector('[data-icon="ChevronDown"]')).not.toBeNull();
+        expect(projectRows[1].querySelector('[data-icon="ChevronRight"]')).not.toBeNull();
+    });
+
+    it('renders the repo link with the correct href', () => {
+        render(<RepoTreeView nodes={nodes} {...defaultProps} expandedProjects={new Set(['p1'])} />);
+        const links = container.querySelectorAll('[data-testid="repo-link"]');
+        expect(links[0].getAttribute('href')).toBe('https://dev.azure.com/org/proj/_git/auth-service');
+    });
+
+    it('shows plain count in pill when filter is not active', () => {
+        render(<RepoTreeView nodes={nodes} {...defaultProps} />);
+        const pills = container.querySelectorAll('[data-testid="pill"]');
+        expect(pills[0].textContent).toBe('2');
+    });
+
+    it('shows "X of Y" in pill when filter is active and counts differ', () => {
+        const filteredNodes = [{ ...nodes[0], filteredRepos: [nodes[0].repos[0]] }];
+        render(<RepoTreeView nodes={filteredNodes} {...defaultProps} filterActive={true} />);
+        const pill = container.querySelector('[data-testid="pill"]')!;
+        expect(pill.textContent).toBe('1 of 2');
+    });
+
+    it('renders nothing inside the card when nodes is empty', () => {
+        render(<RepoTreeView nodes={[]} {...defaultProps} />);
+        expect(container.querySelectorAll('[data-testid="project-row"]')).toHaveLength(0);
+    });
+});

--- a/tests/unit/treeUtils.test.ts
+++ b/tests/unit/treeUtils.test.ts
@@ -1,0 +1,141 @@
+import { buildProjectNodes, applyFilterToTree, projectWebUrl, ProjectNode } from "../../src/common/treeUtils";
+import { GitRepository } from "azure-devops-extension-api/Git";
+
+function makeRepo(name: string, projectId: string, projectName: string, webUrl: string = `https://dev.azure.com/org/${projectName}/_git/${name}`, size: number = 0): GitRepository {
+    return {
+        id: `${projectId}-${name}`,
+        name,
+        webUrl,
+        size,
+        project: { id: projectId, name: projectName }
+    } as unknown as GitRepository;
+}
+
+describe('projectWebUrl', () => {
+    it('strips the /_git/ segment and everything after', () => {
+        const repo = makeRepo('my-repo', 'p1', 'ProjectOne', 'https://dev.azure.com/org/ProjectOne/_git/my-repo');
+        expect(projectWebUrl(repo)).toBe('https://dev.azure.com/org/ProjectOne');
+    });
+
+    it('returns the webUrl unchanged when no /_git/ segment exists', () => {
+        const repo = makeRepo('my-repo', 'p1', 'ProjectOne', 'https://dev.azure.com/org/ProjectOne');
+        expect(projectWebUrl(repo)).toBe('https://dev.azure.com/org/ProjectOne');
+    });
+});
+
+describe('buildProjectNodes', () => {
+    it('returns an empty array for empty input', () => {
+        expect(buildProjectNodes([])).toEqual([]);
+    });
+
+    it('creates one node per unique project', () => {
+        const repos = [
+            makeRepo('repo-a', 'p1', 'Alpha'),
+            makeRepo('repo-b', 'p2', 'Beta'),
+        ];
+        expect(buildProjectNodes(repos)).toHaveLength(2);
+    });
+
+    it('groups repos from the same project into one node', () => {
+        const repos = [
+            makeRepo('repo-a', 'p1', 'Alpha'),
+            makeRepo('repo-b', 'p1', 'Alpha'),
+        ];
+        const nodes = buildProjectNodes(repos);
+        expect(nodes).toHaveLength(1);
+        expect(nodes[0].repos).toHaveLength(2);
+    });
+
+    it('sets projectId and projectName from the repo project', () => {
+        const repos = [makeRepo('repo-a', 'proj-42', 'MyProject')];
+        const nodes = buildProjectNodes(repos);
+        expect(nodes[0].projectId).toBe('proj-42');
+        expect(nodes[0].projectName).toBe('MyProject');
+    });
+
+    it('derives projectUrl by stripping the /_git/ segment', () => {
+        const repos = [makeRepo('repo-a', 'p1', 'Alpha', 'https://dev.azure.com/org/Alpha/_git/repo-a')];
+        const nodes = buildProjectNodes(repos);
+        expect(nodes[0].projectUrl).toBe('https://dev.azure.com/org/Alpha');
+    });
+
+    it('sorts project nodes alphabetically by name', () => {
+        const repos = [
+            makeRepo('repo', 'p3', 'Zeta'),
+            makeRepo('repo', 'p1', 'Alpha'),
+            makeRepo('repo', 'p2', 'Mu'),
+        ];
+        const names = buildProjectNodes(repos).map(n => n.projectName);
+        expect(names).toEqual(['Alpha', 'Mu', 'Zeta']);
+    });
+
+    it('sorts repos within each project alphabetically by name', () => {
+        const repos = [
+            makeRepo('zebra', 'p1', 'Alpha'),
+            makeRepo('apple', 'p1', 'Alpha'),
+            makeRepo('mango', 'p1', 'Alpha'),
+        ];
+        const repoNames = buildProjectNodes(repos)[0].repos.map(r => r.name);
+        expect(repoNames).toEqual(['apple', 'mango', 'zebra']);
+    });
+
+    it('sets filteredRepos equal to repos initially', () => {
+        const repos = [makeRepo('repo-a', 'p1', 'Alpha'), makeRepo('repo-b', 'p1', 'Alpha')];
+        const nodes = buildProjectNodes(repos);
+        expect(nodes[0].filteredRepos).toEqual(nodes[0].repos);
+    });
+});
+
+describe('applyFilterToTree', () => {
+    let nodes: ProjectNode[];
+
+    beforeEach(() => {
+        nodes = buildProjectNodes([
+            makeRepo('auth-service', 'p1', 'Alpha'),
+            makeRepo('payment-api', 'p1', 'Alpha'),
+            makeRepo('auth-backend', 'p2', 'Beta'),
+            makeRepo('frontend', 'p2', 'Beta'),
+        ]);
+    });
+
+    it('returns all nodes with all repos for an empty pattern', () => {
+        const result = applyFilterToTree(nodes, '');
+        expect(result).toHaveLength(2);
+        expect(result[0].filteredRepos).toHaveLength(2);
+        expect(result[1].filteredRepos).toHaveLength(2);
+    });
+
+    it('filters repos within each node by the pattern', () => {
+        const result = applyFilterToTree(nodes, 'auth');
+        const alpha = result.find(n => n.projectName === 'Alpha')!;
+        const beta = result.find(n => n.projectName === 'Beta')!;
+        expect(alpha.filteredRepos.map(r => r.name)).toEqual(['auth-service']);
+        expect(beta.filteredRepos.map(r => r.name)).toEqual(['auth-backend']);
+    });
+
+    it('excludes project nodes where no repos match', () => {
+        const result = applyFilterToTree(nodes, 'payment');
+        expect(result).toHaveLength(1);
+        expect(result[0].projectName).toBe('Alpha');
+    });
+
+    it('returns an empty array when no repos match at all', () => {
+        expect(applyFilterToTree(nodes, 'xyz-no-match')).toHaveLength(0);
+    });
+
+    it('supports wildcard patterns', () => {
+        const result = applyFilterToTree(nodes, 'auth*');
+        expect(result).toHaveLength(2);
+        result.forEach(node => {
+            node.filteredRepos.forEach(repo => {
+                expect(repo.name.toLowerCase()).toContain('auth');
+            });
+        });
+    });
+
+    it('does not mutate the original nodes', () => {
+        const originalFilteredLength = nodes[0].filteredRepos.length;
+        applyFilterToTree(nodes, 'auth');
+        expect(nodes[0].filteredRepos.length).toBe(originalFilteredLength);
+    });
+});


### PR DESCRIPTION
  Summary

  - Adds a grouped tree view to the organisation-level hub alongside the existing flat list, toggled by two icon buttons in the filter
  bar
  - Redesigns the table styling in all views to match the native ADO appearance (Card wrapper, shadow, border, full-width columns,
  GitLogo icon)
  - Row click is the sole navigation/interaction path — no redundant nested links on repo names

  What changed

  Tree view (RepoTreeView, treeUtils)
  - Single Table<TreeItem> renders project and repo rows in one continuous list with a shared header, matching the ADO branch list
  pattern
  - Project rows collapse/expand on click; when a filter is active, matching projects auto-expand and the pill shows X of Y
  - Expand state is kept separate from filter-expand state so manual choices survive when the filter is cleared

  List view (both hubs)
  - Table wrapped in Card with bolt-table-card + bolt-card-white for native ADO shadow and white background
  - Name columns use width: -1 to fill the full screen width
  - GitLogo icon on repository rows; no icon on the Project column

  View toggle buttons
  - Always subtle so button size never changes between states
  - Active state shown via outset box-shadow: 0 0 0 2px currentColor on a wrapper <div> — draws outside the button, works in light and
  dark mode, causes no layout shift

  Test plan

  - Install the dev VSIX from the CI artifact on this PR
  - Verify tree view groups repos by project with correct counts
  - Type a filter — check auto-expand and X of Y pill
  - Clear the filter — check manual expand state is restored
  - Toggle list/tree — confirm active button has a visible ring and no layout shift
  - Click a repo row — confirms navigation to the repository
  - Repeat above in dark mode