### PR TITLE
Add last push column and repository status badges

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -8,6 +8,8 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 
 **Documentation is part of every change.** Whenever a feature is implemented or modified, `README.md`, `overview.md`, and `CLAUDE.md` must all be updated in the same branch before the PR is raised. This is not optional and not a follow-up task — it is part of the definition of done for every change.
 
+**ADO REST API version must not exceed 7.1.** The extension targets Azure DevOps Server (on-premises) which only supports REST API up to version 7.1. The `azure-devops-extension-api` package hardcodes `7.2-preview` in all its client methods, so every method we call is overridden in `src/common/apiClients.ts` using `GitClient71` and `CoreClient71` — subclasses that force `apiVersion: "7.1"`. Never call `getClient(GitRestClient)` or `getClient(CoreRestClient)` directly; always use these wrappers. If a new API method is needed, add an override for it in `apiClients.ts` with `apiVersion: "7.1"`.
+
 **All UI must feel like a natural part of Azure DevOps.** Every design decision — spacing, typography, colour, row height, hover states, dividers, icons — must follow the ADO design language. Use ADO design tokens (`--palette-*`, `--color-*`) rather than hard-coded values. Reach for `azure-devops-ui` components before writing custom HTML. When in doubt, look at how ADO itself renders a similar pattern (branches list, work item list, table) and match it. Never introduce visual styles that feel foreign to the ADO shell.
 
 ## Project Overview

--- a/src/common/apiClients.ts
+++ b/src/common/apiClients.ts
@@ -1,0 +1,46 @@
+import { GitRestClient } from "azure-devops-extension-api/Git";
+import { GitPush, GitPushSearchCriteria, GitRepository } from "azure-devops-extension-api/Git/Git";
+import { CoreRestClient } from "azure-devops-extension-api/Core";
+import { TeamProjectReference } from "azure-devops-extension-api/Core/Core";
+import { PagedList } from "azure-devops-extension-api/WebApi/WebApi";
+import { deserializeVssJsonObject } from "azure-devops-extension-api/Common/Util/Serialization";
+
+// ADO Server only supports REST API up to version 7.1.
+// The azure-devops-extension-api package hardcodes 7.2-preview in all methods,
+// so we override every method we call to pin it to 7.1.
+// Never upgrade past 7.1 without verifying on-prem compatibility.
+
+export class GitClient71 extends GitRestClient {
+    public getRepositories(project?: string, includeLinks?: boolean, includeAllUrls?: boolean, includeHidden?: boolean): Promise<GitRepository[]> {
+        return this.beginRequest<GitRepository[]>({
+            apiVersion: "7.1",
+            routeTemplate: "{project}/_apis/git/Repositories/{repositoryId}",
+            routeValues: { project },
+            queryParams: { includeLinks, includeAllUrls, includeHidden }
+        });
+    }
+
+    public getPushes(repositoryId: string, project?: string, skip?: number, top?: number, searchCriteria?: GitPushSearchCriteria): Promise<GitPush[]> {
+        return this.beginRequest<GitPush[]>({
+            apiVersion: "7.1",
+            routeTemplate: "{project}/_apis/git/repositories/{repositoryId}/pushes/{pushId}",
+            routeValues: { project, repositoryId },
+            queryParams: { '$skip': skip, '$top': top, searchCriteria }
+        });
+    }
+}
+
+export class CoreClient71 extends CoreRestClient {
+    public getProjects(stateFilter?: unknown, top?: number, skip?: number, continuationToken?: number, getDefaultTeamImageUrl?: boolean): Promise<PagedList<TeamProjectReference>> {
+        return this.beginRequest<Response>({
+            apiVersion: "7.1",
+            routeTemplate: "_apis/projects/{*projectId}",
+            queryParams: { stateFilter, '$top': top, '$skip': skip, continuationToken, getDefaultTeamImageUrl },
+            returnRawResponse: true
+        }).then(async (response: Response) => {
+            const body = await response.text().then(deserializeVssJsonObject) as PagedList<TeamProjectReference>;
+            body.continuationToken = response.headers.get("x-ms-continuationtoken");
+            return body;
+        });
+    }
+}

--- a/src/common/dateUtils.ts
+++ b/src/common/dateUtils.ts
@@ -1,0 +1,14 @@
+export function formatRelativeDate(date: Date | null | undefined): string {
+    if (date === undefined) return "—";
+    if (date === null) return "Never";
+    const diffDays = Math.floor((Date.now() - date.getTime()) / 86_400_000);
+    if (diffDays < 1) return "Today";
+    if (diffDays === 1) return "Yesterday";
+    if (diffDays < 7) return `${diffDays} days ago`;
+    const weeks = Math.floor(diffDays / 7);
+    if (weeks < 5) return `${weeks} week${weeks === 1 ? "" : "s"} ago`;
+    const months = Math.floor(diffDays / 30);
+    if (months < 12) return `${months} month${months === 1 ? "" : "s"} ago`;
+    const years = Math.floor(diffDays / 365);
+    return `${years} year${years === 1 ? "" : "s"} ago`;
+}

--- a/src/common/repoUtils.tsx
+++ b/src/common/repoUtils.tsx
@@ -1,0 +1,20 @@
+import * as React from "react";
+import { GitRepository } from "azure-devops-extension-api/Git";
+import { Icon } from "azure-devops-ui/Icon";
+import { Pill, PillSize, PillVariant } from "azure-devops-ui/Pill";
+import { ISimpleListCell } from "azure-devops-ui/List";
+
+export function repoNameCell(repo: GitRepository, indent?: boolean): ISimpleListCell {
+    return {
+        textNode: (
+            <div className="repo-name-cell">
+                {indent && <span className="tree-repo-indent" />}
+                <Icon iconName="GitLogo" />
+                <span className="repo-name-text">{repo.name}</span>
+                {repo.isFork && <Pill size={PillSize.compact} variant={PillVariant.outlined}>Fork</Pill>}
+                {repo.isDisabled && <Pill size={PillSize.compact} variant={PillVariant.outlined}>Disabled</Pill>}
+                {repo.isInMaintenance && <Pill size={PillSize.compact} variant={PillVariant.outlined}>Maintenance</Pill>}
+            </div>
+        )
+    };
+}

--- a/src/org-hub/Pivot.css
+++ b/src/org-hub/Pivot.css
@@ -29,6 +29,20 @@
 }
 
 
+/* Repository name cell with optional status badges */
+.repo-name-cell {
+    display: flex;
+    align-items: center;
+    gap: 8px;
+    min-width: 0;
+}
+
+.repo-name-text {
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+}
+
 /* Tree view */
 .tree-project-cell {
     display: flex;
@@ -36,6 +50,11 @@
     gap: 6px;
     width: 100%;
     cursor: pointer;
+}
+
+.tree-repo-indent {
+    width: 20px;
+    flex-shrink: 0;
 }
 
 .tree-project-name {

--- a/src/org-hub/Pivot.tsx
+++ b/src/org-hub/Pivot.tsx
@@ -8,6 +8,8 @@ import * as SDK from "azure-devops-extension-sdk";
 import { showRootComponent } from "../common/Common";
 import { applyFilter } from "../common/repositoryFilter";
 import { buildProjectNodes, applyFilterToTree, projectWebUrl, ProjectNode } from "../common/treeUtils";
+import { repoNameCell } from "../common/repoUtils";
+import { formatRelativeDate } from "../common/dateUtils";
 import { RepoTreeView } from "./RepoTreeView";
 
 import { getClient, IHostNavigationService, CommonServiceIds } from "azure-devops-extension-api";
@@ -42,10 +44,14 @@ class PivotContent extends React.Component<{}, IPivotContentState> {
     private repositories: GitRepository[] = [];
     private allProjectNodes: ProjectNode[] = [];
     private navigationService?: IHostNavigationService;
+    private _mounted = false;
+    private lastPushByRepoId: Map<string, Date | null> = new Map();
 
+    // Column indices: 0=name, 1=project, 2=lastPush, 3=size
     private sortFunctions: Array<(a: GitRepository, b: GitRepository) => number> = [
         (a, b) => a.name.localeCompare(b.name),
         (a, b) => a.project.name.localeCompare(b.project.name),
+        (a, b) => (this.lastPushByRepoId.get(a.id)?.getTime() ?? -1) - (this.lastPushByRepoId.get(b.id)?.getTime() ?? -1),
         (a, b) => (Number.isNaN(a.size) ? 0 : a.size) - (Number.isNaN(b.size) ? 0 : b.size)
     ];
 
@@ -69,8 +75,7 @@ class PivotContent extends React.Component<{}, IPivotContentState> {
                     name: "Repository",
                     sortProps: { sortOrder: SortOrder.ascending },
                     renderCell: (rowIndex, columnIndex, tableColumn, tableItem): JSX.Element => {
-                        const content: ISimpleListCell = { text: tableItem.name, iconProps: { iconName: "GitLogo" } };
-                        return renderSimpleCellValue<any>(columnIndex, tableColumn, content);
+                        return renderSimpleCellValue<any>(columnIndex, tableColumn, repoNameCell(tableItem));
                     },
                     width: -1
                 },
@@ -83,6 +88,15 @@ class PivotContent extends React.Component<{}, IPivotContentState> {
                         return renderSimpleCellValue<any>(columnIndex, tableColumn, content);
                     },
                     width: 200
+                },
+                {
+                    id: "lastPush",
+                    name: "Last push",
+                    sortProps: {},
+                    renderCell: (rowIndex, columnIndex, tableColumn, tableItem): JSX.Element => {
+                        return renderSimpleCellValue<any>(columnIndex, tableColumn, formatRelativeDate(this.lastPushByRepoId.get(tableItem.id)));
+                    },
+                    width: 130
                 },
                 {
                     id: "size",
@@ -106,8 +120,13 @@ class PivotContent extends React.Component<{}, IPivotContentState> {
     }
 
     public componentDidMount() {
+        this._mounted = true;
         SDK.init();
         this.initializeComponent();
+    }
+
+    public componentWillUnmount() {
+        this._mounted = false;
     }
 
     private async initializeComponent() {
@@ -129,6 +148,30 @@ class PivotContent extends React.Component<{}, IPivotContentState> {
             nbrRepos: this.repositories.length,
             expandedProjects: new Set(this.allProjectNodes.map(n => n.projectId))
         });
+
+        this.loadPushDates(this.repositories);
+    }
+
+    private async loadPushDates(repos: GitRepository[]): Promise<void> {
+        const BATCH_SIZE = 50;
+        for (let i = 0; i < repos.length; i += BATCH_SIZE) {
+            if (!this._mounted) return;
+            const batch = repos.slice(i, i + BATCH_SIZE);
+            const results = await Promise.all(
+                batch.map(async (repo): Promise<{ id: string; date: Date | null }> => {
+                    try {
+                        const pushes = await getClient(GitRestClient).getPushes(repo.id, repo.project.name, undefined, 1);
+                        return { id: repo.id, date: pushes.length > 0 ? pushes[0].date : null };
+                    } catch {
+                        return { id: repo.id, date: null };
+                    }
+                })
+            );
+            if (!this._mounted) return;
+            results.forEach(({ id, date }) => this.lastPushByRepoId.set(id, date));
+            const filtered = applyFilter(this.repositories, this.state.filterText);
+            this.setState({ gitRepos: new ArrayItemProvider(filtered) });
+        }
     }
 
     private onRowActivate = (event: React.SyntheticEvent<HTMLElement>, row: ITableRow<GitRepository>) => {
@@ -247,6 +290,7 @@ class PivotContent extends React.Component<{}, IPivotContentState> {
                                 onToggleProject={this.onToggleProject}
                                 onNavigateToRepo={(url) => this.navigationService?.navigate(url)}
                                 filterActive={isFiltering}
+                                lastPushByRepoId={this.lastPushByRepoId}
                             />
                         )}
                     </div>

--- a/src/org-hub/Pivot.tsx
+++ b/src/org-hub/Pivot.tsx
@@ -13,8 +13,9 @@ import { formatRelativeDate } from "../common/dateUtils";
 import { RepoTreeView } from "./RepoTreeView";
 
 import { getClient, IHostNavigationService, CommonServiceIds } from "azure-devops-extension-api";
-import { CoreRestClient, TeamProjectReference } from "azure-devops-extension-api/Core";
-import { GitRestClient, GitRepository } from "azure-devops-extension-api/Git";
+import { TeamProjectReference } from "azure-devops-extension-api/Core";
+import { GitRepository } from "azure-devops-extension-api/Git";
+import { GitClient71, CoreClient71 } from "../common/apiClients";
 
 import { Table, ITableColumn, ITableRow, renderSimpleCellValue, ColumnSorting, sortItems, SortOrder } from "azure-devops-ui/Table";
 import { ArrayItemProvider } from "azure-devops-ui/Utilities/Provider";
@@ -132,10 +133,10 @@ class PivotContent extends React.Component<{}, IPivotContentState> {
     private async initializeComponent() {
         this.navigationService = await SDK.getService<IHostNavigationService>(CommonServiceIds.HostNavigationService);
 
-        const projects = await getClient(CoreRestClient).getProjects();
+        const projects = await getClient(CoreClient71).getProjects();
         let repositories: GitRepository[] = [];
         for (const project of projects) {
-            const repos = await getClient(GitRestClient).getRepositories(project.name);
+            const repos = await getClient(GitClient71).getRepositories(project.name);
             repositories = repositories.concat(repos);
         }
 
@@ -160,7 +161,7 @@ class PivotContent extends React.Component<{}, IPivotContentState> {
             const results = await Promise.all(
                 batch.map(async (repo): Promise<{ id: string; date: Date | null }> => {
                     try {
-                        const pushes = await getClient(GitRestClient).getPushes(repo.id, repo.project.name, undefined, 1);
+                        const pushes = await getClient(GitClient71).getPushes(repo.id, repo.project.name, undefined, 1);
                         return { id: repo.id, date: pushes.length > 0 ? pushes[0].date : null };
                     } catch {
                         return { id: repo.id, date: null };

--- a/src/org-hub/RepoTreeView.tsx
+++ b/src/org-hub/RepoTreeView.tsx
@@ -1,12 +1,13 @@
 import * as React from "react";
 import { GitRepository } from "azure-devops-extension-api/Git";
 import { ProjectNode } from "../common/treeUtils";
+import { repoNameCell } from "../common/repoUtils";
+import { formatRelativeDate } from "../common/dateUtils";
 import { Card } from "azure-devops-ui/Card";
 import { Icon } from "azure-devops-ui/Icon";
 import { Pill, PillSize, PillVariant } from "azure-devops-ui/Pill";
 import { Table, ITableColumn, ITableRow, renderSimpleCellValue } from "azure-devops-ui/Table";
 import { ArrayItemProvider } from "azure-devops-ui/Utilities/Provider";
-import { ISimpleListCell } from "azure-devops-ui/List";
 
 type TreeItem =
     | { kind: "project"; node: ProjectNode; expanded: boolean }
@@ -18,6 +19,7 @@ export interface IRepoTreeViewProps {
     onToggleProject: (projectId: string) => void;
     onNavigateToRepo: (url: string) => void;
     filterActive: boolean;
+    lastPushByRepoId: Map<string, Date | null>;
 }
 
 function formatSize(bytes: number): string {
@@ -50,14 +52,17 @@ function buildFlatItems(nodes: ProjectNode[], expandedProjects: Set<string>): Tr
     return items;
 }
 
-function buildColumns(filterActive: boolean): ITableColumn<TreeItem>[] {
+function buildColumns(
+    filterActive: boolean,
+    lastPushByRepoId: Map<string, Date | null>
+): ITableColumn<TreeItem>[] {
     return [
         {
             id: "name",
             name: "Repository",
             renderCell: (_rowIndex, columnIndex, tableColumn, item) => {
                 if (item.kind === "project") {
-                    const content: ISimpleListCell = {
+                    const content = {
                         textNode: (
                             <div className="tree-project-cell">
                                 <Icon iconName={item.expanded ? "ChevronDown" : "ChevronRight"} className="flex-noshrink" />
@@ -71,13 +76,20 @@ function buildColumns(filterActive: boolean): ITableColumn<TreeItem>[] {
                     };
                     return renderSimpleCellValue<any>(columnIndex, tableColumn, content);
                 }
-                const content: ISimpleListCell = {
-                    text: item.repo.name,
-                    iconProps: { iconName: "GitLogo" }
-                };
-                return renderSimpleCellValue<any>(columnIndex, tableColumn, content);
+                return renderSimpleCellValue<any>(columnIndex, tableColumn, repoNameCell(item.repo, true));
             },
             width: -1
+        },
+        {
+            id: "lastPush",
+            name: "Last push",
+            renderCell: (_rowIndex, columnIndex, tableColumn, item) => {
+                if (item.kind === "project") {
+                    return renderSimpleCellValue<any>(columnIndex, tableColumn, "");
+                }
+                return renderSimpleCellValue<any>(columnIndex, tableColumn, formatRelativeDate(lastPushByRepoId.get(item.repo.id)));
+            },
+            width: 130
         },
         {
             id: "size",
@@ -93,9 +105,9 @@ function buildColumns(filterActive: boolean): ITableColumn<TreeItem>[] {
     ];
 }
 
-export function RepoTreeView({ nodes, expandedProjects, onToggleProject, onNavigateToRepo, filterActive }: IRepoTreeViewProps): JSX.Element {
+export function RepoTreeView({ nodes, expandedProjects, onToggleProject, onNavigateToRepo, filterActive, lastPushByRepoId }: IRepoTreeViewProps): JSX.Element {
     const items = buildFlatItems(nodes, expandedProjects);
-    const columns = buildColumns(filterActive);
+    const columns = buildColumns(filterActive, lastPushByRepoId);
 
     const onActivate = (_event: React.SyntheticEvent<HTMLElement>, row: ITableRow<TreeItem>) => {
         const item = row.data;

--- a/src/repos-hub/ServiceHub.css
+++ b/src/repos-hub/ServiceHub.css
@@ -3,3 +3,16 @@
     margin: 0 25px;
     padding-bottom: 16px;
 }
+
+.repo-name-cell {
+    display: flex;
+    align-items: center;
+    gap: 8px;
+    min-width: 0;
+}
+
+.repo-name-text {
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+}

--- a/src/repos-hub/ServiceHub.tsx
+++ b/src/repos-hub/ServiceHub.tsx
@@ -13,6 +13,8 @@ import { Table, ITableColumn, ITableRow, renderSimpleCellValue, ColumnSorting, s
 import { Card } from "azure-devops-ui/Card";
 import { showRootComponent } from "../common/Common";
 import { applyFilter } from "../common/repositoryFilter";
+import { repoNameCell } from "../common/repoUtils";
+import { formatRelativeDate } from "../common/dateUtils";
 import { GitRepository } from "azure-devops-extension-api/Git/Git";
 import { CommonServiceIds, IHostNavigationService, IProjectPageService, getClient } from "azure-devops-extension-api";
 import { ISimpleListCell } from "azure-devops-ui/List";
@@ -31,9 +33,13 @@ interface IRepositoryServiceHubContentState {
 class RepositoryServiceHubContent extends React.Component<{}, IRepositoryServiceHubContentState> {
     private repositories: GitRepository[] = [];
     private navigationService?: IHostNavigationService;
+    private _mounted = false;
+    private lastPushByRepoId: Map<string, Date | null> = new Map();
 
+    // Column indices: 0=name, 1=lastPush, 2=size
     private sortFunctions: Array<(a: GitRepository, b: GitRepository) => number> = [
         (a, b) => a.name.localeCompare(b.name),
+        (a, b) => (this.lastPushByRepoId.get(a.id)?.getTime() ?? -1) - (this.lastPushByRepoId.get(b.id)?.getTime() ?? -1),
         (a, b) => (Number.isNaN(a.size) ? 0 : a.size) - (Number.isNaN(b.size) ? 0 : b.size)
     ];
 
@@ -57,10 +63,18 @@ class RepositoryServiceHubContent extends React.Component<{}, IRepositoryService
                     name: "Repository",
                     sortProps: { sortOrder: SortOrder.ascending },
                     renderCell: (rowIndex, columnIndex, tableColumn, tableItem): JSX.Element => {
-                        const content: ISimpleListCell = { text: tableItem.name, iconProps: { iconName: "GitLogo" } };
-                        return renderSimpleCellValue<any>(columnIndex, tableColumn, content);
+                        return renderSimpleCellValue<any>(columnIndex, tableColumn, repoNameCell(tableItem));
                     },
                     width: -1
+                },
+                {
+                    id: "lastPush",
+                    name: "Last push",
+                    sortProps: {},
+                    renderCell: (rowIndex, columnIndex, tableColumn, tableItem): JSX.Element => {
+                        return renderSimpleCellValue<any>(columnIndex, tableColumn, formatRelativeDate(this.lastPushByRepoId.get(tableItem.id)));
+                    },
+                    width: 130
                 },
                 {
                     id: "size",
@@ -81,6 +95,7 @@ class RepositoryServiceHubContent extends React.Component<{}, IRepositoryService
     }
 
     public async componentWillMount() {
+        this._mounted = true;
         SDK.init();
 
         this.navigationService = await SDK.getService<IHostNavigationService>(CommonServiceIds.HostNavigationService);
@@ -98,6 +113,34 @@ class RepositoryServiceHubContent extends React.Component<{}, IRepositoryService
             gitRepos: new ArrayItemProvider([...this.repositories]),
             nbrRepos: this.repositories.length
         });
+
+        this.loadPushDates(this.repositories);
+    }
+
+    public componentWillUnmount() {
+        this._mounted = false;
+    }
+
+    private async loadPushDates(repos: GitRepository[]): Promise<void> {
+        const BATCH_SIZE = 50;
+        for (let i = 0; i < repos.length; i += BATCH_SIZE) {
+            if (!this._mounted) return;
+            const batch = repos.slice(i, i + BATCH_SIZE);
+            const results = await Promise.all(
+                batch.map(async (repo): Promise<{ id: string; date: Date | null }> => {
+                    try {
+                        const pushes = await getClient(GitRestClient).getPushes(repo.id, repo.project.name, undefined, 1);
+                        return { id: repo.id, date: pushes.length > 0 ? pushes[0].date : null };
+                    } catch {
+                        return { id: repo.id, date: null };
+                    }
+                })
+            );
+            if (!this._mounted) return;
+            results.forEach(({ id, date }) => this.lastPushByRepoId.set(id, date));
+            const filtered = applyFilter(this.repositories, this.state.filterText);
+            this.setState({ gitRepos: new ArrayItemProvider(filtered) });
+        }
     }
 
     private onRowActivate = (event: React.SyntheticEvent<HTMLElement>, row: ITableRow<GitRepository>) => {

--- a/src/repos-hub/ServiceHub.tsx
+++ b/src/repos-hub/ServiceHub.tsx
@@ -18,7 +18,7 @@ import { formatRelativeDate } from "../common/dateUtils";
 import { GitRepository } from "azure-devops-extension-api/Git/Git";
 import { CommonServiceIds, IHostNavigationService, IProjectPageService, getClient } from "azure-devops-extension-api";
 import { ISimpleListCell } from "azure-devops-ui/List";
-import { GitRestClient } from "azure-devops-extension-api/Git";
+import { GitClient71 } from "../common/apiClients";
 import { ArrayItemProvider } from "azure-devops-ui/Utilities/Provider";
 import { Pill, PillSize, PillVariant } from 'azure-devops-ui/Pill';
 import { TextField } from "azure-devops-ui/TextField";
@@ -104,7 +104,7 @@ class RepositoryServiceHubContent extends React.Component<{}, IRepositoryService
         const project = await projectService.getProject();
         let repos: GitRepository[] = [];
         if (project) {
-            repos = await getClient(GitRestClient).getRepositories(project.name);
+            repos = await getClient(GitClient71).getRepositories(project.name);
         }
 
         this.repositories = sortItems(0, SortOrder.ascending, this.sortFunctions, this.state.columns, repos);
@@ -129,7 +129,7 @@ class RepositoryServiceHubContent extends React.Component<{}, IRepositoryService
             const results = await Promise.all(
                 batch.map(async (repo): Promise<{ id: string; date: Date | null }> => {
                     try {
-                        const pushes = await getClient(GitRestClient).getPushes(repo.id, repo.project.name, undefined, 1);
+                        const pushes = await getClient(GitClient71).getPushes(repo.id, repo.project.name, undefined, 1);
                         return { id: repo.id, date: pushes.length > 0 ? pushes[0].date : null };
                     } catch {
                         return { id: repo.id, date: null };

--- a/tests/unit/RepoTreeView.test.tsx
+++ b/tests/unit/RepoTreeView.test.tsx
@@ -22,12 +22,13 @@ jest.mock("azure-devops-ui/Pill", () => ({
 jest.mock("azure-devops-ui/Table", () => ({
     Table: ({ itemProvider, onActivate, columns }: any) => {
         const items: any[] = itemProvider.value;
+        const nameCol = columns?.find((c: any) => c.id === "name");
+        const lastPushCol = columns?.find((c: any) => c.id === "lastPush");
         return (
             <div data-testid="tree-table">
                 {items.map((item: any, i: number) => {
+                    const nameCell = nameCol?.renderCell?.(i, 0, nameCol, item);
                     if (item.kind === "project") {
-                        const nameCol = columns?.[0];
-                        const nameCell = nameCol?.renderCell?.(i, 0, nameCol, item);
                         return (
                             <div
                                 key={item.node.projectId}
@@ -40,13 +41,15 @@ jest.mock("azure-devops-ui/Table", () => ({
                             </div>
                         );
                     }
+                    const lastPushCell = lastPushCol?.renderCell?.(i, 1, lastPushCol, item);
                     return (
                         <div
                             key={item.repo.id || i}
                             data-testid="repo-row"
                             onClick={() => onActivate?.({}, { data: item })}
                         >
-                            <a href={item.repo.webUrl} data-testid="repo-link">{item.repo.name}</a>
+                            {nameCell}
+                            <span data-testid="last-push-cell">{lastPushCell}</span>
                         </div>
                     );
                 })}
@@ -55,12 +58,9 @@ jest.mock("azure-devops-ui/Table", () => ({
     },
     renderSimpleCellValue: (_colIdx: any, _tableCol: any, content: any) => {
         if (content?.textNode) {
-            return <td>{content.textNode}</td>;
+            return <>{content.textNode}</>;
         }
-        if (content?.href) {
-            return <td><a href={content.href}>{content.text}</a></td>;
-        }
-        return <td>{typeof content === "string" ? content : null}</td>;
+        return <>{typeof content === "string" ? content : null}</>;
     }
 }));
 
@@ -73,8 +73,17 @@ jest.mock("azure-devops-ui/Utilities/Provider", () => ({
     }
 }));
 
-function makeRepo(name: string, id: string, webUrl: string = `https://dev.azure.com/org/proj/_git/${name}`): GitRepository {
-    return { id, name, webUrl, size: 1000000 } as unknown as GitRepository;
+function makeRepo(name: string, id: string, overrides: Partial<GitRepository> = {}): GitRepository {
+    return {
+        id,
+        name,
+        webUrl: `https://dev.azure.com/org/proj/_git/${name}`,
+        size: 1000000,
+        isFork: false,
+        isDisabled: false,
+        isInMaintenance: false,
+        ...overrides
+    } as unknown as GitRepository;
 }
 
 function makeNode(projectId: string, projectName: string, repoNames: string[]): ProjectNode {
@@ -108,7 +117,8 @@ const defaultProps = {
     expandedProjects: new Set<string>(),
     onToggleProject: () => {},
     onNavigateToRepo: () => {},
-    filterActive: false
+    filterActive: false,
+    lastPushByRepoId: new Map<string, Date | null>()
 };
 
 describe('RepoTreeView', () => {
@@ -170,10 +180,10 @@ describe('RepoTreeView', () => {
         expect(projectRows[1].querySelector('[data-icon="ChevronRight"]')).not.toBeNull();
     });
 
-    it('renders the repo link with the correct href', () => {
+    it('shows the repo name in each repo row', () => {
         render(<RepoTreeView nodes={nodes} {...defaultProps} expandedProjects={new Set(['p1'])} />);
-        const links = container.querySelectorAll('[data-testid="repo-link"]');
-        expect(links[0].getAttribute('href')).toBe('https://dev.azure.com/org/proj/_git/auth-service');
+        const repoRows = container.querySelectorAll('[data-testid="repo-row"]');
+        expect(repoRows[0].textContent).toContain('auth-service');
     });
 
     it('shows plain count in pill when filter is not active', () => {
@@ -192,5 +202,48 @@ describe('RepoTreeView', () => {
     it('renders nothing inside the card when nodes is empty', () => {
         render(<RepoTreeView nodes={[]} {...defaultProps} />);
         expect(container.querySelectorAll('[data-testid="project-row"]')).toHaveLength(0);
+    });
+
+    it('shows "—" in last push cell when push date is not yet loaded', () => {
+        render(<RepoTreeView nodes={nodes} {...defaultProps} expandedProjects={new Set(['p1'])} />);
+        const lastPushCells = container.querySelectorAll('[data-testid="last-push-cell"]');
+        expect(lastPushCells[0].textContent).toBe('—');
+    });
+
+    it('shows "Never" in last push cell when repo has no pushes', () => {
+        const map = new Map<string, Date | null>([['p1-0', null]]);
+        render(<RepoTreeView nodes={nodes} {...defaultProps} expandedProjects={new Set(['p1'])} lastPushByRepoId={map} />);
+        const lastPushCells = container.querySelectorAll('[data-testid="last-push-cell"]');
+        expect(lastPushCells[0].textContent).toBe('Never');
+    });
+
+    it('shows relative date in last push cell when push date is loaded', () => {
+        const yesterday = new Date(Date.now() - 86_400_000);
+        const map = new Map<string, Date | null>([['p1-0', yesterday]]);
+        render(<RepoTreeView nodes={nodes} {...defaultProps} expandedProjects={new Set(['p1'])} lastPushByRepoId={map} />);
+        const lastPushCells = container.querySelectorAll('[data-testid="last-push-cell"]');
+        expect(lastPushCells[0].textContent).toBe('Yesterday');
+    });
+
+    it('shows Fork badge for forked repositories', () => {
+        const forkNodes = [makeNode('p1', 'Alpha', [])];
+        const forkRepo = makeRepo('forked-repo', 'p1-0', { isFork: true });
+        forkNodes[0].repos = [forkRepo];
+        forkNodes[0].filteredRepos = [forkRepo];
+        render(<RepoTreeView nodes={forkNodes} {...defaultProps} expandedProjects={new Set(['p1'])} />);
+        const repoRow = container.querySelector('[data-testid="repo-row"]')!;
+        const pills = repoRow.querySelectorAll('[data-testid="pill"]');
+        expect(Array.from(pills).some(p => p.textContent === 'Fork')).toBe(true);
+    });
+
+    it('shows Disabled badge for disabled repositories', () => {
+        const disabledNodes = [makeNode('p1', 'Alpha', [])];
+        const disabledRepo = makeRepo('disabled-repo', 'p1-0', { isDisabled: true });
+        disabledNodes[0].repos = [disabledRepo];
+        disabledNodes[0].filteredRepos = [disabledRepo];
+        render(<RepoTreeView nodes={disabledNodes} {...defaultProps} expandedProjects={new Set(['p1'])} />);
+        const repoRow = container.querySelector('[data-testid="repo-row"]')!;
+        const pills = repoRow.querySelectorAll('[data-testid="pill"]');
+        expect(Array.from(pills).some(p => p.textContent === 'Disabled')).toBe(true);
     });
 });

--- a/tests/unit/dateUtils.test.ts
+++ b/tests/unit/dateUtils.test.ts
@@ -1,0 +1,48 @@
+import { formatRelativeDate } from "../../src/common/dateUtils";
+
+function daysAgo(n: number): Date {
+    return new Date(Date.now() - n * 86_400_000);
+}
+
+describe("formatRelativeDate", () => {
+    it('returns "—" for undefined', () => {
+        expect(formatRelativeDate(undefined)).toBe("—");
+    });
+
+    it('returns "Never" for null', () => {
+        expect(formatRelativeDate(null)).toBe("Never");
+    });
+
+    it('returns "Today" for a date less than 1 day ago', () => {
+        expect(formatRelativeDate(new Date(Date.now() - 3_600_000))).toBe("Today");
+    });
+
+    it('returns "Yesterday" for exactly 1 day ago', () => {
+        expect(formatRelativeDate(daysAgo(1))).toBe("Yesterday");
+    });
+
+    it('returns "X days ago" for 2–6 days ago', () => {
+        expect(formatRelativeDate(daysAgo(3))).toBe("3 days ago");
+        expect(formatRelativeDate(daysAgo(6))).toBe("6 days ago");
+    });
+
+    it('returns "1 week ago" for 7 days ago', () => {
+        expect(formatRelativeDate(daysAgo(7))).toBe("1 week ago");
+    });
+
+    it('returns "X weeks ago" for 8–34 days ago', () => {
+        expect(formatRelativeDate(daysAgo(14))).toBe("2 weeks ago");
+        expect(formatRelativeDate(daysAgo(28))).toBe("4 weeks ago");
+    });
+
+    it('returns "X month(s) ago" for 35–364 days ago', () => {
+        expect(formatRelativeDate(daysAgo(35))).toBe("1 month ago");
+        expect(formatRelativeDate(daysAgo(60))).toBe("2 months ago");
+        expect(formatRelativeDate(daysAgo(300))).toBe("10 months ago");
+    });
+
+    it('returns "X year(s) ago" for 365+ days ago', () => {
+        expect(formatRelativeDate(daysAgo(365))).toBe("1 year ago");
+        expect(formatRelativeDate(daysAgo(730))).toBe("2 years ago");
+    });
+});


### PR DESCRIPTION
  Summary

  - Adds a Last push sortable column to all table views, loaded lazily so initial render stays fast even for thousands of repositories
  - Adds inline Fork, Disabled, and Maintenance pills in the Repository name cell — free from the existing API response, no extra calls

  What changed

  Last push (lazy, getPushes with top=1)
  - After the initial repo list renders, loadPushDates fires in background batches of 50 parallel requests
  - Each completed batch triggers a re-render, filling the column progressively (— while loading → relative date or Never)
  - Sortable: clicking the column header sorts by known dates; repos not yet loaded sort to the bottom
  - A _mounted guard stops batches cleanly if the component unmounts mid-load
  - formatRelativeDate in src/common/dateUtils.ts covers Today / Yesterday / N days / weeks / months / years / Never / — (loading)

  Status badges (isFork, isDisabled, isInMaintenance)
  - Shared repoNameCell() in src/common/repoUtils.tsx renders the GitLogo icon + name + any applicable pills
  - Used in org-hub list, project-hub list, and org-hub tree view — single source of truth

  Test plan

  - Install dev VSIX from CI on this PR
  - Verify repo list appears immediately; Last push column shows — then fills in
  - Sort by Last push — stale repos bubble to top/bottom
  - Navigate to a project with a forked/disabled repo — check badge appears in name cell
  - Verify no noticeable extra loading delay on the initial page render