### PR TITLE
Improve org hub tree view toggle

### DIFF
--- a/src/org-hub/OrgHub.tsx
+++ b/src/org-hub/OrgHub.tsx
@@ -261,7 +261,7 @@ class OrgHubContent extends React.Component<{}, IOrgHubState> {
                                 <div className={`view-toggle-wrapper${viewMode === "tree" ? " view-toggle-wrapper--active" : ""}`}>
                                     <Button
                                         subtle={true}
-                                        iconProps={{ iconName: "Group" }}
+                                        iconProps={{ iconName: "Org" }}
                                         ariaLabel="Tree view"
                                         ariaPressed={viewMode === "tree"}
                                         onClick={() => this.onToggleViewMode("tree")}

--- a/src/org-hub/OrgHub.tsx
+++ b/src/org-hub/OrgHub.tsx
@@ -42,6 +42,16 @@ interface IOrgHubState {
 }
 
 class OrgHubContent extends React.Component<{}, IOrgHubState> {
+    private static readonly VIEW_MODE_KEY = "org-hub-view-mode";
+
+    private static readViewMode(): ViewMode {
+        try {
+            const saved = localStorage.getItem(OrgHubContent.VIEW_MODE_KEY);
+            if (saved === "list" || saved === "tree") return saved;
+        } catch { /* storage unavailable */ }
+        return "list";
+    }
+
     private repositories: GitRepository[] = [];
     private allProjectNodes: ProjectNode[] = [];
     private navigationService?: IHostNavigationService;
@@ -114,7 +124,7 @@ class OrgHubContent extends React.Component<{}, IOrgHubState> {
             ],
             nbrRepos: 0,
             filterText: "",
-            viewMode: "list",
+            viewMode: OrgHubContent.readViewMode(),
             expandedProjects: new Set(),
             filterExpandedProjects: new Set()
         };
@@ -196,6 +206,7 @@ class OrgHubContent extends React.Component<{}, IOrgHubState> {
 
     private onToggleViewMode = (mode: ViewMode) => {
         this.setState({ viewMode: mode });
+        try { localStorage.setItem(OrgHubContent.VIEW_MODE_KEY, mode); } catch { /* storage unavailable */ }
     };
 
     private onToggleProject = (projectId: string) => {


### PR DESCRIPTION
   ## Summary

   - Replace the **Group** icon on the tree view toggle button with **Org**, which shows an org-chart/hierarchy shape — the standard
   toolbar metaphor for a tree view
   - Persist the selected view mode (list or tree) across sessions using `localStorage`, read synchronously in the constructor so the
   correct view is selected on the very first render with no flicker

   ## Test plan

   - [x] Switch to tree view — Org icon button appears active
   - [x] Reload the page — tree view is still selected immediately on load, no flash of list view
   - [x] Switch back to list view and reload — list view is correctly restored
   - [x] Verify the project hub (repos tab inside a project) is unaffected and always loads as list view
   - [x] Build passes: `npm run build`
   - [x] Tests pass: `npm test`