### PR TITLE
Add lazy-loaded Open PRs column to all repository views

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -169,7 +169,7 @@ src/
     Common.tsx            # Shared showRootComponent helper
     repositoryFilter.ts   # Wildcard/substring filter logic for repo name filtering
     treeUtils.ts          # ProjectNode type, buildProjectNodes, applyFilterToTree
-    repoUtils.tsx         # repoNameCell — shared repo name cell renderer
+    repoUtils.tsx         # repoNameCell, prCountCell, PrCounts — shared repo cell renderers and types
     dateUtils.ts          # formatRelativeDate utility
     apiClients.ts         # GitClient71, CoreClient71 — API version 7.1 wrappers
     styles.css            # Shared styles
@@ -207,3 +207,15 @@ The organisation-level hub (`OrgHub.tsx`) supports two view modes toggled by the
 - Expand state is split across two `Set<string>` instances in `OrgHubContent` state: `expandedProjects` (user's manual choices, all projects seeded on load) and `filterExpandedProjects` (auto-computed when filter is active). `activeExpandedProjects()` returns whichever is current.
 - The `azure-devops-ui` package does **not** include a Tree component. The visual treatment (folder background `--palette-neutral-4`, 36px row height, border separators, inset chevrons) is implemented in plain CSS to match the ADO branches list.
 - View toggle buttons are always `subtle={true}`; the active state is indicated with `box-shadow: 0 0 0 2px currentColor` on a wrapper div to avoid layout shift from border/padding changes.
+- The selected view mode is persisted in `localStorage` under the key `org-hub-view-mode` and read synchronously in the constructor so the correct view is set before the first render. No async call is needed.
+
+### Lazy-loaded column data
+
+Both hubs load two sets of per-repository data in the background after the initial repo list renders: **last push dates** and **open PR counts**. The pattern is identical for both:
+
+- A `Map<string, T>` is held as a private class field (not in React state).
+- A `loadX` method fetches data in batches of 50 using `Promise.all`, sets the map entries, then calls `setState` to trigger a re-render with the updated data.
+- Both loaders run concurrently via parallel `this.loadPushDates()` / `this.loadPrCounts()` calls.
+- Cells render empty while their entry is absent from the map, then fill in as batches arrive.
+- PR counts are fetched with `GitClient71.getActivePullRequests` (status=active, top=1000). Draft PRs are a subset of active — `isDraft: true` — so a single call gives both counts. Clicking the count cell navigates to `repo.webUrl + "/pullrequests?_a=active"`. `stopPropagation` is called on the click to prevent the row's own navigation from also firing.
+- The PR sort key is `active * 10000 + draft` so active count takes priority over draft count when sorting.

--- a/README.md
+++ b/README.md
@@ -48,14 +48,18 @@ To generate a coverage report (minimum 80% line coverage is enforced):
 
 Available from the collection/organisation start page, this hub lists every git repository across all projects the current user has access to.
 
-Two view modes are available via the toggle buttons at the top right of the filter bar:
+Two view modes are available via the toggle buttons at the top right of the filter bar. The selected mode is persisted per browser so the same view is restored on next load.
 
-- **List view** (default) — a flat table with sortable columns: repository name, project, and size.
-- **Tree view** — repositories grouped by project, with collapsible project nodes. Each project header shows a count pill (or `3 of 10` when filtering). Styled to match the ADO branches list.
+- **List view** (default) — a flat table with sortable columns: Repository, Project, Last push, Open PRs, Size.
+- **Tree view** — repositories grouped by project, with collapsible project nodes. Each project header shows a count pill (or `3 of 10` when filtering). Columns: Repository, Last push, Open PRs, Size. Styled to match the ADO branches list.
+
+### Open PRs column
+
+Shows `draft | active` pull request counts for each repository, lazy-loaded in the background after the list renders. Clicking the count navigates to that repository's active pull request list. The column is sortable — active count takes priority over draft count.
 
 ## Repository list (project level)
 
-Available under the Repos section inside each project, this hub lists all git repositories within that project. Columns show the repository name and its size. All columns are sortable.
+Available under the Repos section inside each project, this hub lists all git repositories within that project. Sortable columns: Repository, Last push, Open PRs, Size. The Open PRs column behaves identically to the organisation-level hub.
 
 ## Filtering
 

--- a/overview.md
+++ b/overview.md
@@ -16,9 +16,19 @@ This extension adds two new ways to view all the git repositories in your collec
 
 Both views include a filter input at the top of the page. Type any part of a repository name to narrow the list instantly. Wildcard patterns using `*` are also supported — for example `auth*` to match names starting with "auth", or `*-service` to match names containing "-service". The counter next to the page title updates to show how many repositories are currently visible out of the total (e.g. `5 of 42`).
 
+## Last push
+
+Both hubs display when each repository was last pushed to. The value is lazy-loaded in the background after the list appears and updates automatically as data arrives. The column is sortable.
+
+## Open PRs
+
+Each repository row shows a `draft | active` pull request count, lazy-loaded after the list renders. Hovering the count shows a tooltip (`2 draft, 5 active`). Clicking it navigates directly to that repository's active pull request list. The column is sortable — repositories with more active PRs rank higher.
+
 ## Tree view (organisation level)
 
 The organisation-level hub offers a toggle between the default flat list and a tree view that groups repositories by project. Each project node can be expanded or collapsed individually. When a filter is active, only projects containing matching repositories are shown, and they expand automatically. The tree view is styled to match the Azure DevOps branches list.
+
+The selected view mode (list or tree) is remembered per browser and restored automatically on next load.
 
 ## Privacy notice
 
@@ -27,7 +37,8 @@ No data is collected from this extension. Your data is your own. For further det
 ## Release notes
 
 ### 1.1.0
-
+- Feature: **Open PRs column** — each repository row now shows a `draft | active` pull request count, lazy-loaded after the list renders. Hovering shows a tooltip; clicking navigates to the active PR tab. Sortable by active count.
+- Feature: **Last push column** — shows relative date of the most recent push per repository, lazy-loaded in batches.
 - Feature: Tree view added to the organisation-level hub. Toggle between the existing flat list and a new grouped view that organises repositories by project. Each project node is collapsible, shows a repository count pill, and auto-expands when a filter is active.
 - Feature: Filter input added to both hubs. Plain-text typing does a case-insensitive substring match; patterns with `*` use glob-style matching. The count pill next to the title shows `5 of 42` while a filter is active.
 - Feature: Sortable columns — click any column header to toggle between ascending and descending order.

--- a/src/common/apiClients.ts
+++ b/src/common/apiClients.ts
@@ -1,5 +1,5 @@
 import { GitRestClient } from "azure-devops-extension-api/Git";
-import { GitPush, GitPushSearchCriteria, GitRepository } from "azure-devops-extension-api/Git/Git";
+import { GitPullRequest, GitPush, GitPushSearchCriteria, GitRepository } from "azure-devops-extension-api/Git/Git";
 import { CoreRestClient } from "azure-devops-extension-api/Core";
 import { TeamProjectReference } from "azure-devops-extension-api/Core/Core";
 import { PagedList } from "azure-devops-extension-api/WebApi/WebApi";
@@ -26,6 +26,15 @@ export class GitClient71 extends GitRestClient {
             routeTemplate: "{project}/_apis/git/repositories/{repositoryId}/pushes/{pushId}",
             routeValues: { project, repositoryId },
             queryParams: { '$skip': skip, '$top': top, searchCriteria }
+        });
+    }
+
+    public getActivePullRequests(repositoryId: string, project: string, top: number): Promise<GitPullRequest[]> {
+        return this.beginRequest<GitPullRequest[]>({
+            apiVersion: "7.1",
+            routeTemplate: "{project}/_apis/git/repositories/{repositoryId}/pullRequests/{pullRequestId}",
+            routeValues: { project, repositoryId },
+            queryParams: { searchCriteria: { status: "active" }, '$top': top }
         });
     }
 }

--- a/src/common/repoUtils.tsx
+++ b/src/common/repoUtils.tsx
@@ -4,6 +4,23 @@ import { Icon } from "azure-devops-ui/Icon";
 import { Pill, PillSize, PillVariant } from "azure-devops-ui/Pill";
 import { ISimpleListCell } from "azure-devops-ui/List";
 
+export interface PrCounts { draft: number; active: number; }
+
+export function prCountCell(counts: PrCounts | undefined, onNavigate: (e: React.MouseEvent) => void): ISimpleListCell {
+    if (counts === undefined) return { text: "" };
+    return {
+        textNode: (
+            <span
+                className="pr-count-cell"
+                title={`${counts.draft} draft, ${counts.active} active`}
+                onClick={(e) => { e.stopPropagation(); onNavigate(e); }}
+            >
+                {`${counts.draft} | ${counts.active}`}
+            </span>
+        )
+    };
+}
+
 export function repoNameCell(repo: GitRepository, indent?: boolean): ISimpleListCell {
     return {
         textNode: (

--- a/src/common/styles.css
+++ b/src/common/styles.css
@@ -13,3 +13,12 @@
   margin-top: 16px;
   margin-bottom: 16px;
 }
+
+.pr-count-cell {
+  cursor: pointer;
+  color: var(--communication-foreground);
+}
+
+.pr-count-cell:hover {
+  text-decoration: underline;
+}

--- a/src/org-hub/OrgHub.tsx
+++ b/src/org-hub/OrgHub.tsx
@@ -8,7 +8,7 @@ import * as SDK from "azure-devops-extension-sdk";
 import { showRootComponent } from "../common/Common";
 import { applyFilter } from "../common/repositoryFilter";
 import { buildProjectNodes, applyFilterToTree, projectWebUrl, ProjectNode } from "../common/treeUtils";
-import { repoNameCell } from "../common/repoUtils";
+import { repoNameCell, prCountCell, PrCounts } from "../common/repoUtils";
 import { formatRelativeDate } from "../common/dateUtils";
 import { RepoTreeView } from "./RepoTreeView";
 
@@ -57,12 +57,20 @@ class OrgHubContent extends React.Component<{}, IOrgHubState> {
     private navigationService?: IHostNavigationService;
     private _mounted = false;
     private lastPushByRepoId: Map<string, Date | null> = new Map();
+    private prCountByRepoId: Map<string, PrCounts> = new Map();
 
-    // Column indices: 0=name, 1=project, 2=lastPush, 3=size
+    // Column indices: 0=name, 1=project, 2=lastPush, 3=prs, 4=size
     private sortFunctions: Array<(a: GitRepository, b: GitRepository) => number> = [
         (a, b) => a.name.localeCompare(b.name),
         (a, b) => a.project.name.localeCompare(b.project.name),
         (a, b) => (this.lastPushByRepoId.get(a.id)?.getTime() ?? -1) - (this.lastPushByRepoId.get(b.id)?.getTime() ?? -1),
+        (a, b) => {
+            const ac = this.prCountByRepoId.get(a.id);
+            const bc = this.prCountByRepoId.get(b.id);
+            const aKey = (ac?.active ?? 0) * 10000 + (ac?.draft ?? 0);
+            const bKey = (bc?.active ?? 0) * 10000 + (bc?.draft ?? 0);
+            return aKey - bKey;
+        },
         (a, b) => (Number.isNaN(a.size) ? 0 : a.size) - (Number.isNaN(b.size) ? 0 : b.size)
     ];
 
@@ -108,6 +116,18 @@ class OrgHubContent extends React.Component<{}, IOrgHubState> {
                         return renderSimpleCellValue<any>(columnIndex, tableColumn, formatRelativeDate(this.lastPushByRepoId.get(tableItem.id)));
                     },
                     width: 130
+                },
+                {
+                    id: "prs",
+                    name: "Open PRs",
+                    sortProps: {},
+                    renderCell: (rowIndex, columnIndex, tableColumn, tableItem): JSX.Element => {
+                        return renderSimpleCellValue<any>(columnIndex, tableColumn, prCountCell(
+                            this.prCountByRepoId.get(tableItem.id),
+                            () => this.navigationService?.navigate(tableItem.webUrl + "/pullrequests?_a=active")
+                        ));
+                    },
+                    width: 110
                 },
                 {
                     id: "size",
@@ -161,6 +181,30 @@ class OrgHubContent extends React.Component<{}, IOrgHubState> {
         });
 
         this.loadPushDates(this.repositories);
+        this.loadPrCounts(this.repositories);
+    }
+
+    private async loadPrCounts(repos: GitRepository[]): Promise<void> {
+        const BATCH_SIZE = 50;
+        for (let i = 0; i < repos.length; i += BATCH_SIZE) {
+            if (!this._mounted) return;
+            const batch = repos.slice(i, i + BATCH_SIZE);
+            const results = await Promise.all(
+                batch.map(async (repo): Promise<{ id: string; counts: PrCounts }> => {
+                    try {
+                        const prs = await getClient(GitClient71).getActivePullRequests(repo.id, repo.project.name, 1000);
+                        const draft = prs.filter(pr => pr.isDraft).length;
+                        return { id: repo.id, counts: { draft, active: prs.length - draft } };
+                    } catch {
+                        return { id: repo.id, counts: { draft: 0, active: 0 } };
+                    }
+                })
+            );
+            if (!this._mounted) return;
+            results.forEach(({ id, counts }) => this.prCountByRepoId.set(id, counts));
+            const filtered = applyFilter(this.repositories, this.state.filterText);
+            this.setState({ gitRepos: new ArrayItemProvider(filtered) });
+        }
     }
 
     private async loadPushDates(repos: GitRepository[]): Promise<void> {
@@ -300,9 +344,10 @@ class OrgHubContent extends React.Component<{}, IOrgHubState> {
                                 nodes={applyFilterToTree(this.allProjectNodes, filterText)}
                                 expandedProjects={this.activeExpandedProjects()}
                                 onToggleProject={this.onToggleProject}
-                                onNavigateToRepo={(url) => this.navigationService?.navigate(url)}
+                                onNavigate={(url) => this.navigationService?.navigate(url)}
                                 filterActive={isFiltering}
                                 lastPushByRepoId={this.lastPushByRepoId}
+                                prCountByRepoId={this.prCountByRepoId}
                             />
                         )}
                     </div>

--- a/src/org-hub/RepoTreeView.tsx
+++ b/src/org-hub/RepoTreeView.tsx
@@ -1,7 +1,7 @@
 import * as React from "react";
 import { GitRepository } from "azure-devops-extension-api/Git";
 import { ProjectNode } from "../common/treeUtils";
-import { repoNameCell } from "../common/repoUtils";
+import { repoNameCell, prCountCell, PrCounts } from "../common/repoUtils";
 import { formatRelativeDate } from "../common/dateUtils";
 import { Card } from "azure-devops-ui/Card";
 import { Icon } from "azure-devops-ui/Icon";
@@ -17,9 +17,10 @@ export interface IRepoTreeViewProps {
     nodes: ProjectNode[];
     expandedProjects: Set<string>;
     onToggleProject: (projectId: string) => void;
-    onNavigateToRepo: (url: string) => void;
+    onNavigate: (url: string) => void;
     filterActive: boolean;
     lastPushByRepoId: Map<string, Date | null>;
+    prCountByRepoId: Map<string, PrCounts>;
 }
 
 function formatSize(bytes: number): string {
@@ -54,7 +55,9 @@ function buildFlatItems(nodes: ProjectNode[], expandedProjects: Set<string>): Tr
 
 function buildColumns(
     filterActive: boolean,
-    lastPushByRepoId: Map<string, Date | null>
+    lastPushByRepoId: Map<string, Date | null>,
+    prCountByRepoId: Map<string, PrCounts>,
+    onNavigate: (url: string) => void
 ): ITableColumn<TreeItem>[] {
     return [
         {
@@ -92,6 +95,20 @@ function buildColumns(
             width: 130
         },
         {
+            id: "prs",
+            name: "Open PRs",
+            renderCell: (_rowIndex, columnIndex, tableColumn, item) => {
+                if (item.kind === "project") {
+                    return renderSimpleCellValue<any>(columnIndex, tableColumn, "");
+                }
+                return renderSimpleCellValue<any>(columnIndex, tableColumn, prCountCell(
+                    prCountByRepoId.get(item.repo.id),
+                    () => onNavigate(item.repo.webUrl + "/pullrequests?_a=active")
+                ));
+            },
+            width: 110
+        },
+        {
             id: "size",
             name: "Size",
             renderCell: (_rowIndex, columnIndex, tableColumn, item) => {
@@ -105,16 +122,16 @@ function buildColumns(
     ];
 }
 
-export function RepoTreeView({ nodes, expandedProjects, onToggleProject, onNavigateToRepo, filterActive, lastPushByRepoId }: IRepoTreeViewProps): JSX.Element {
+export function RepoTreeView({ nodes, expandedProjects, onToggleProject, onNavigate, filterActive, lastPushByRepoId, prCountByRepoId }: IRepoTreeViewProps): JSX.Element {
     const items = buildFlatItems(nodes, expandedProjects);
-    const columns = buildColumns(filterActive, lastPushByRepoId);
+    const columns = buildColumns(filterActive, lastPushByRepoId, prCountByRepoId, onNavigate);
 
     const onActivate = (_event: React.SyntheticEvent<HTMLElement>, row: ITableRow<TreeItem>) => {
         const item = row.data;
         if (item.kind === "project") {
             onToggleProject(item.node.projectId);
         } else {
-            onNavigateToRepo(item.repo.webUrl);
+            onNavigate(item.repo.webUrl);
         }
     };
 

--- a/src/repos-hub/ProjectHub.tsx
+++ b/src/repos-hub/ProjectHub.tsx
@@ -13,11 +13,10 @@ import { Table, ITableColumn, ITableRow, renderSimpleCellValue, ColumnSorting, s
 import { Card } from "azure-devops-ui/Card";
 import { showRootComponent } from "../common/Common";
 import { applyFilter } from "../common/repositoryFilter";
-import { repoNameCell } from "../common/repoUtils";
+import { repoNameCell, prCountCell, PrCounts } from "../common/repoUtils";
 import { formatRelativeDate } from "../common/dateUtils";
 import { GitRepository } from "azure-devops-extension-api/Git/Git";
 import { CommonServiceIds, IHostNavigationService, IProjectPageService, getClient } from "azure-devops-extension-api";
-import { ISimpleListCell } from "azure-devops-ui/List";
 import { GitClient71 } from "../common/apiClients";
 import { ArrayItemProvider } from "azure-devops-ui/Utilities/Provider";
 import { Pill, PillSize, PillVariant } from 'azure-devops-ui/Pill';
@@ -35,11 +34,19 @@ class ProjectHubContent extends React.Component<{}, IProjectHubState> {
     private navigationService?: IHostNavigationService;
     private _mounted = false;
     private lastPushByRepoId: Map<string, Date | null> = new Map();
+    private prCountByRepoId: Map<string, PrCounts> = new Map();
 
-    // Column indices: 0=name, 1=lastPush, 2=size
+    // Column indices: 0=name, 1=lastPush, 2=prs, 3=size
     private sortFunctions: Array<(a: GitRepository, b: GitRepository) => number> = [
         (a, b) => a.name.localeCompare(b.name),
         (a, b) => (this.lastPushByRepoId.get(a.id)?.getTime() ?? -1) - (this.lastPushByRepoId.get(b.id)?.getTime() ?? -1),
+        (a, b) => {
+            const ac = this.prCountByRepoId.get(a.id);
+            const bc = this.prCountByRepoId.get(b.id);
+            const aKey = (ac?.active ?? 0) * 10000 + (ac?.draft ?? 0);
+            const bKey = (bc?.active ?? 0) * 10000 + (bc?.draft ?? 0);
+            return aKey - bKey;
+        },
         (a, b) => (Number.isNaN(a.size) ? 0 : a.size) - (Number.isNaN(b.size) ? 0 : b.size)
     ];
 
@@ -75,6 +82,18 @@ class ProjectHubContent extends React.Component<{}, IProjectHubState> {
                         return renderSimpleCellValue<any>(columnIndex, tableColumn, formatRelativeDate(this.lastPushByRepoId.get(tableItem.id)));
                     },
                     width: 130
+                },
+                {
+                    id: "prs",
+                    name: "Open PRs",
+                    sortProps: {},
+                    renderCell: (rowIndex, columnIndex, tableColumn, tableItem): JSX.Element => {
+                        return renderSimpleCellValue<any>(columnIndex, tableColumn, prCountCell(
+                            this.prCountByRepoId.get(tableItem.id),
+                            () => this.navigationService?.navigate(tableItem.webUrl + "/pullrequests?_a=active")
+                        ));
+                    },
+                    width: 110
                 },
                 {
                     id: "size",
@@ -115,10 +134,34 @@ class ProjectHubContent extends React.Component<{}, IProjectHubState> {
         });
 
         this.loadPushDates(this.repositories);
+        this.loadPrCounts(this.repositories);
     }
 
     public componentWillUnmount() {
         this._mounted = false;
+    }
+
+    private async loadPrCounts(repos: GitRepository[]): Promise<void> {
+        const BATCH_SIZE = 50;
+        for (let i = 0; i < repos.length; i += BATCH_SIZE) {
+            if (!this._mounted) return;
+            const batch = repos.slice(i, i + BATCH_SIZE);
+            const results = await Promise.all(
+                batch.map(async (repo): Promise<{ id: string; counts: PrCounts }> => {
+                    try {
+                        const prs = await getClient(GitClient71).getActivePullRequests(repo.id, repo.project.name, 1000);
+                        const draft = prs.filter(pr => pr.isDraft).length;
+                        return { id: repo.id, counts: { draft, active: prs.length - draft } };
+                    } catch {
+                        return { id: repo.id, counts: { draft: 0, active: 0 } };
+                    }
+                })
+            );
+            if (!this._mounted) return;
+            results.forEach(({ id, counts }) => this.prCountByRepoId.set(id, counts));
+            const filtered = applyFilter(this.repositories, this.state.filterText);
+            this.setState({ gitRepos: new ArrayItemProvider(filtered) });
+        }
     }
 
     private async loadPushDates(repos: GitRepository[]): Promise<void> {

--- a/tests/unit/RepoTreeView.test.tsx
+++ b/tests/unit/RepoTreeView.test.tsx
@@ -24,6 +24,7 @@ jest.mock("azure-devops-ui/Table", () => ({
         const items: any[] = itemProvider.value;
         const nameCol = columns?.find((c: any) => c.id === "name");
         const lastPushCol = columns?.find((c: any) => c.id === "lastPush");
+        const prsCol = columns?.find((c: any) => c.id === "prs");
         return (
             <div data-testid="tree-table">
                 {items.map((item: any, i: number) => {
@@ -42,6 +43,7 @@ jest.mock("azure-devops-ui/Table", () => ({
                         );
                     }
                     const lastPushCell = lastPushCol?.renderCell?.(i, 1, lastPushCol, item);
+                    const prsCell = prsCol?.renderCell?.(i, 2, prsCol, item);
                     return (
                         <div
                             key={item.repo.id || i}
@@ -50,6 +52,7 @@ jest.mock("azure-devops-ui/Table", () => ({
                         >
                             {nameCell}
                             <span data-testid="last-push-cell">{lastPushCell}</span>
+                            <span data-testid="prs-cell">{prsCell}</span>
                         </div>
                     );
                 })}
@@ -116,9 +119,10 @@ function render(ui: JSX.Element) {
 const defaultProps = {
     expandedProjects: new Set<string>(),
     onToggleProject: () => {},
-    onNavigateToRepo: () => {},
+    onNavigate: () => {},
     filterActive: false,
-    lastPushByRepoId: new Map<string, Date | null>()
+    lastPushByRepoId: new Map<string, Date | null>(),
+    prCountByRepoId: new Map<string, { draft: number; active: number }>()
 };
 
 describe('RepoTreeView', () => {
@@ -164,13 +168,25 @@ describe('RepoTreeView', () => {
         expect(handler).toHaveBeenCalledWith('p1');
     });
 
-    it('calls onNavigateToRepo when a repo row is activated', () => {
+    it('calls onNavigate when a repo row is activated', () => {
         const handler = jest.fn();
-        render(<RepoTreeView nodes={nodes} {...defaultProps} expandedProjects={new Set(['p1'])} onNavigateToRepo={handler} />);
+        render(<RepoTreeView nodes={nodes} {...defaultProps} expandedProjects={new Set(['p1'])} onNavigate={handler} />);
         act(() => {
             (container.querySelector('[data-testid="repo-row"]') as HTMLElement).click();
         });
         expect(handler).toHaveBeenCalledWith('https://dev.azure.com/org/proj/_git/auth-service');
+    });
+
+    it('shows PR counts when loaded', () => {
+        const prMap = new Map([['p1-0', { draft: 1, active: 3 }]]);
+        render(<RepoTreeView nodes={nodes} {...defaultProps} expandedProjects={new Set(['p1'])} prCountByRepoId={prMap} />);
+        expect(container.textContent).toContain('1 | 3');
+    });
+
+    it('shows empty PR cell when counts are not yet loaded', () => {
+        render(<RepoTreeView nodes={nodes} {...defaultProps} expandedProjects={new Set(['p1'])} />);
+        const repoRow = container.querySelector('[data-testid="repo-row"]')!;
+        expect(repoRow.querySelector('[class="pr-count-cell"]')).toBeNull();
     });
 
     it('renders ChevronDown icon for expanded projects and ChevronRight for collapsed', () => {


### PR DESCRIPTION
## Summary

  - Each repository row in both hubs now shows a draft | active pull request count, lazy-loaded in the background after the list renders
  — the list appears immediately at full speed and PR counts fill in as data arrives.
  - Hovering the count shows a tooltip (2 draft, 5 active). Clicking it navigates directly to that repository's active PR tab. Row click
  behaviour is unaffected.
  - The column is sortable — repositories with more active PRs rank higher (sort key: active × 10000 + draft).
  - Applies to the org-hub list view, the org-hub tree view, and the project hub.

## Test plan

  - Load the org-hub — repo list appears without waiting for PR data; counts fill in per batch
  - Load the project hub — same lazy-load behaviour
  - Hover a PR count cell — tooltip shows N draft, N active
  - Click a PR count — lands on the Active tab of that repo's PR list (not "Mine")
  - Click elsewhere on the row — navigates to the repo (PR click does not also fire this)
  - Click a 0 | 0 cell — navigates to the active PR tab of a repo with no PRs
  - Sort by Open PRs ascending and descending — active count determines rank, draft as tiebreaker
  - All 61 unit tests pass (npm test)